### PR TITLE
Remove redundant line in User Guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -73,10 +73,6 @@ Lists the application commands that are available in the system.
 
 Format: `help`
 
-Example: `[help]` Lists all available commands.
-
-
-
 ### Adding a person: `add`
 
 Adds a person to the address book.


### PR DESCRIPTION
Remove redundant line in the help command in the user guide. 