### PR TITLE
Add ApplicationStatus and InterviewStatus

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -171,12 +171,8 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-<<<<<<< HEAD
-            return CollectionUtil.isAnyNonNull(studentId, name, phone, email, course, tags);
-=======
-            return CollectionUtil.isAnyNonNull(studentID, name, phone, email, course, tags,
+            return CollectionUtil.isAnyNonNull(studentId, name, phone, email, course, tags,
                     applicationStatus, interviewStatus);
->>>>>>> origin/6869-add-status-attribute
         }
 
         public void setStudentId(StudentId id) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -1,9 +1,11 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPLICATION_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -20,8 +22,10 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.ApplicationStatus;
 import seedu.address.model.person.Course;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.InterviewStatus;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -44,7 +48,9 @@ public class EditCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_COURSE + "COURSE] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + "TAG]..."
+            + "[" + PREFIX_APPLICATION_STATUS + "APPLICATION STATUS]"
+            + "[" + PREFIX_INTERVIEW_STATUS + "INTERVIEW STATUS]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
@@ -102,8 +108,13 @@ public class EditCommand extends Command {
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Course updatedCourse = editPersonDescriptor.getCourse().orElse(personToEdit.getCourse());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
+        ApplicationStatus applicationStatus = editPersonDescriptor.getApplicationStatus()
+                .orElse(personToEdit.getApplicationStatus());
+        InterviewStatus interviewStatus = editPersonDescriptor.getInterviewStatus()
+                .orElse(personToEdit.getInterviewStatus());
 
-        return new Person(updatedID, updatedName, updatedPhone, updatedEmail, updatedCourse, updatedTags);
+        return new Person(updatedID, updatedName, updatedPhone, updatedEmail,
+                updatedCourse, updatedTags, applicationStatus, interviewStatus);
     }
 
     @Override
@@ -136,6 +147,8 @@ public class EditCommand extends Command {
         private Course course;
 
         private Set<Tag> tags;
+        private ApplicationStatus applicationStatus;
+        private InterviewStatus interviewStatus;
 
         public EditPersonDescriptor() {}
 
@@ -150,13 +163,20 @@ public class EditCommand extends Command {
             setEmail(toCopy.email);
             setCourse(toCopy.course);
             setTags(toCopy.tags);
+            setApplicationStatus(toCopy.applicationStatus);
+            setInterviewStatus(toCopy.interviewStatus);
         }
 
         /**
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
+<<<<<<< HEAD
             return CollectionUtil.isAnyNonNull(studentId, name, phone, email, course, tags);
+=======
+            return CollectionUtil.isAnyNonNull(studentID, name, phone, email, course, tags,
+                    applicationStatus, interviewStatus);
+>>>>>>> origin/6869-add-status-attribute
         }
 
         public void setStudentId(StudentId id) {
@@ -199,6 +219,21 @@ public class EditCommand extends Command {
             return Optional.ofNullable(course);
         }
 
+        public void setApplicationStatus(ApplicationStatus applicationStatus) {
+            this.applicationStatus = applicationStatus;
+        }
+
+        public Optional<ApplicationStatus> getApplicationStatus() {
+            return Optional.ofNullable(applicationStatus);
+        }
+
+        public void setInterviewStatus(InterviewStatus interviewStatus) {
+            this.interviewStatus = interviewStatus;
+        }
+
+        public Optional<InterviewStatus> getInterviewStatus() {
+            return Optional.ofNullable(interviewStatus);
+        }
         /**
          * Sets {@code tags} to this object's {@code tags}.
          * A defensive copy of {@code tags} is used internally.
@@ -236,7 +271,9 @@ public class EditCommand extends Command {
                     && getPhone().equals(e.getPhone())
                     && getEmail().equals(e.getEmail())
                     && getCourse().equals(e.getCourse())
-                    && getTags().equals(e.getTags());
+                    && getTags().equals(e.getTags())
+                    && getApplicationStatus().equals(e.getApplicationStatus())
+                    && getInterviewStatus().equals(e.getInterviewStatus());
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -12,8 +12,10 @@ import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.ApplicationStatus;
 import seedu.address.model.person.Course;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.InterviewStatus;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -46,8 +48,10 @@ public class AddCommandParser implements Parser<AddCommand> {
         Email email = new Email(id.studentId);
         Course course = ParserUtil.parseCourse(argMultimap.getValue(PREFIX_COURSE).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        ApplicationStatus applicationStatus = new ApplicationStatus(ApplicationStatus.PENDING_STATUS);
+        InterviewStatus interviewStatus = new InterviewStatus(InterviewStatus.PENDING_STATUS);
 
-        Person person = new Person(id, name, phone, email, course, tagList);
+        Person person = new Person(id, name, phone, email, course, tagList, applicationStatus, interviewStatus);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -14,4 +14,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_KEYWORD = new Prefix("k/");
     public static final Prefix PREFIX_FIELD = new Prefix("f/");
+    public static final Prefix PREFIX_APPLICATION_STATUS = new Prefix("as/");
+    public static final Prefix PREFIX_INTERVIEW_STATUS = new Prefix("is/");
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -2,9 +2,11 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPLICATION_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -34,7 +36,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_ID, PREFIX_NAME, PREFIX_PHONE,
-                        PREFIX_EMAIL, PREFIX_COURSE, PREFIX_TAG);
+                        PREFIX_EMAIL, PREFIX_COURSE, PREFIX_TAG, PREFIX_APPLICATION_STATUS, PREFIX_INTERVIEW_STATUS);
 
         Index index;
 
@@ -45,6 +47,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
+
         if (argMultimap.getValue(PREFIX_ID).isPresent()) {
             editPersonDescriptor.setStudentId(ParserUtil.parseStudentId(argMultimap.getValue(PREFIX_ID).get()));
         }
@@ -60,7 +63,18 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_COURSE).isPresent()) {
             editPersonDescriptor.setCourse(ParserUtil.parseCourse(argMultimap.getValue(PREFIX_COURSE).get()));
         }
+
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
+
+        if (argMultimap.getValue(PREFIX_APPLICATION_STATUS).isPresent()) {
+            editPersonDescriptor.setApplicationStatus(
+                    ParserUtil.parseApplicationStatus(argMultimap.getValue(PREFIX_APPLICATION_STATUS).get()));
+        }
+
+        if (argMultimap.getValue(PREFIX_INTERVIEW_STATUS).isPresent()) {
+            editPersonDescriptor.setInterviewStatus(
+                    ParserUtil.parseInterviewStatus(argMultimap.getValue(PREFIX_INTERVIEW_STATUS).get()));
+        }
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -10,8 +10,10 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.ApplicationStatus;
 import seedu.address.model.person.Course;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.InterviewStatus;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.StudentId;
@@ -152,5 +154,37 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses a {@code String applicationStatus} into an {@code ApplicationStatus}.
+     *
+     * @param applicationStatus the application status
+     * @return the ApplicationStatus of the string
+     * @throws ParseException if the given {@code applicationStatus} is invalid.
+     */
+    public static ApplicationStatus parseApplicationStatus (String applicationStatus) throws ParseException {
+        requireNonNull(applicationStatus);
+        String trimmedStatus = applicationStatus.trim();
+        if (!ApplicationStatus.isValidStatus(trimmedStatus)) {
+            throw new ParseException(ApplicationStatus.MESSAGE_CONSTRAINTS);
+        }
+        return new ApplicationStatus(trimmedStatus);
+    }
+
+    /**
+     * Parses a {@code String interviewStatus} into an {@code InterviewStatus}.
+     *
+     * @param interviewStatus the application status
+     * @return the InterviewStatus of the string
+     * @throws ParseException if the given {@code interviewStatus} is invalid.
+     */
+    public static InterviewStatus parseInterviewStatus (String interviewStatus) throws ParseException {
+        requireNonNull(interviewStatus);
+        String trimmedStatus = interviewStatus.trim();
+        if (!InterviewStatus.isValidStatus(trimmedStatus)) {
+            throw new ParseException(InterviewStatus.MESSAGE_CONSTRAINTS);
+        }
+        return new InterviewStatus(trimmedStatus);
     }
 }

--- a/src/main/java/seedu/address/model/person/ApplicationStatus.java
+++ b/src/main/java/seedu/address/model/person/ApplicationStatus.java
@@ -1,0 +1,66 @@
+package seedu.address.model.person;
+
+public class ApplicationStatus {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Application Status should be Pending, Accepted or Rejected";
+    public static final String PENDING_STATUS = "Pending";
+    public static final String ACCPETED_STATUS = "Accepted";
+    public static final String REJECTED_STATUS = "Rejected";
+
+    private String statusType;
+
+    /**
+     * Constructor for Application Status.
+     *
+     * @param statusType the string value of the status.
+     */
+    public ApplicationStatus(String statusType) {
+        String input = statusType.toLowerCase();
+        if (input.equals(PENDING_STATUS.toLowerCase())) {
+            this.statusType = PENDING_STATUS;
+        } else if (input.equals(ACCPETED_STATUS.toLowerCase())) {
+            this.statusType = ACCPETED_STATUS;
+        } else if (input.equals(REJECTED_STATUS.toLowerCase())) {
+            this.statusType = REJECTED_STATUS;
+        }
+    }
+
+    /**
+     * Check if the status is a valid status.
+     *
+     * @param statusType the status type.
+     * @return true if it is valid, false if not valid.
+     */
+    public static boolean isValidStatus(String statusType) {
+        String input = statusType.toLowerCase();
+        if (input.equals(PENDING_STATUS.toLowerCase())
+                || input.equals(ACCPETED_STATUS.toLowerCase())
+                || input.equals(REJECTED_STATUS.toLowerCase())) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the string value of the Status.
+     *
+     * @return a string of the status.
+     */
+    @Override
+    public String toString() {
+        return this.statusType;
+    }
+
+    /**
+     * Check if the statuses are equal.
+     *
+     * @param other the other object of the same class.
+     * @return true if equal, false if not.
+     */
+    @Override
+    public boolean equals(Object other) {
+        return ((ApplicationStatus) other).statusType.equals(this.statusType);
+    }
+}

--- a/src/main/java/seedu/address/model/person/InterviewStatus.java
+++ b/src/main/java/seedu/address/model/person/InterviewStatus.java
@@ -1,0 +1,77 @@
+package seedu.address.model.person;
+
+public class InterviewStatus {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Interview Status should be Pending, Interviewing or Not Interviewed";
+    public static final String PENDING_STATUS = "Pending";
+    public static final String INTERVIEWING_STATUS = "Interviewing";
+    public static final String NOT_INTERVIEWED_STATUS = "Not Interviewed";
+
+    private String interviewStatus;
+
+    /**
+     * Constructor for Interview Status.
+     *
+     * @param interviewStatusType the string value of the status.
+     */
+    public InterviewStatus(String interviewStatusType) {
+        String input = interviewStatusType.toLowerCase();
+        input = input.replaceAll(" ", "");
+
+        if (input.equals(PENDING_STATUS.toLowerCase())) {
+            this.interviewStatus = PENDING_STATUS;
+        } else if (input.equals(INTERVIEWING_STATUS.toLowerCase())) {
+            this.interviewStatus = INTERVIEWING_STATUS;
+        } else if (input.equals(NOT_INTERVIEWED_STATUS
+                .replaceAll(" ", "").toLowerCase())) {
+            this.interviewStatus = NOT_INTERVIEWED_STATUS;
+        }
+    }
+
+    /**
+     * Check if the status is a valid status.
+     *
+     * @param interviewStatusType the status type.
+     * @return true if it is valid, false if not valid.
+     */
+    public static boolean isValidStatus(String interviewStatusType) {
+
+        String input = interviewStatusType.toLowerCase();
+        input = input.replaceAll(" ", "");
+
+        if (input.equals(PENDING_STATUS.toLowerCase())
+                || input.equals(INTERVIEWING_STATUS.toLowerCase())
+                || input.equals(NOT_INTERVIEWED_STATUS.replaceAll(" ", "")
+                .toLowerCase())) {
+
+            return true;
+        } else {
+            return false;
+        }
+
+    }
+
+    /**
+     * Returns the string value of the Status.
+     *
+     * @return a string of the status.
+     */
+    @Override
+    public String toString() {
+        return interviewStatus;
+    }
+
+
+    /**
+     * Check if the statuses are equal.
+     *
+     * @param other the other object of the same class.
+     * @return true if equal, false if not.
+     */
+    @Override
+    public boolean equals(Object other) {
+        return ((InterviewStatus) other).interviewStatus.equals(this.interviewStatus);
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -30,17 +30,10 @@ public class Person {
     /**
      * Every field must be present and not null.
      */
-<<<<<<< HEAD
-    public Person(StudentId studentId, Name name, Phone phone, Email email, Course course, Set<Tag> tags) {
+    public Person(StudentId studentId, Name name, Phone phone, Email email, Course course, Set<Tag> tags,
+                  ApplicationStatus applicationStatus, InterviewStatus interviewStatus) {
         requireAllNonNull(studentId, name, phone, email, course, tags);
         this.studentId = studentId;
-=======
-    public Person(StudentID studentID, Name name, Phone phone, Email email, Course course, Set<Tag> tags,
-                  ApplicationStatus applicationStatus, InterviewStatus interviewStatus) {
-
-        requireAllNonNull(studentID, name, phone, email, course, tags, applicationStatus, interviewStatus);
-        this.studentID = studentID;
->>>>>>> origin/6869-add-status-attribute
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -127,12 +120,7 @@ public class Person {
 
     @Override
     public int hashCode() {
-        // use this method for custom fields hashing instead of implementing your own
-<<<<<<< HEAD
-        return Objects.hash(studentId, name, phone, email, course, tags);
-=======
-        return Objects.hash(studentID, name, phone, email, course, tags, applicationStatus, interviewStatus);
->>>>>>> origin/6869-add-status-attribute
+        return Objects.hash(studentId, name, phone, email, course, tags, applicationStatus, interviewStatus);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -21,6 +21,8 @@ public class Person {
     private final Phone phone;
     private final Email email;
     private final Course course;
+    private final ApplicationStatus applicationStatus;
+    private final InterviewStatus interviewStatus;
 
     // Data fields
     private final Set<Tag> tags = new HashSet<>();
@@ -28,14 +30,24 @@ public class Person {
     /**
      * Every field must be present and not null.
      */
+<<<<<<< HEAD
     public Person(StudentId studentId, Name name, Phone phone, Email email, Course course, Set<Tag> tags) {
         requireAllNonNull(studentId, name, phone, email, course, tags);
         this.studentId = studentId;
+=======
+    public Person(StudentID studentID, Name name, Phone phone, Email email, Course course, Set<Tag> tags,
+                  ApplicationStatus applicationStatus, InterviewStatus interviewStatus) {
+
+        requireAllNonNull(studentID, name, phone, email, course, tags, applicationStatus, interviewStatus);
+        this.studentID = studentID;
+>>>>>>> origin/6869-add-status-attribute
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.course = course;
         this.tags.addAll(tags);
+        this.applicationStatus = applicationStatus;
+        this.interviewStatus = interviewStatus;
     }
 
     public StudentId getStudentId() {
@@ -56,6 +68,14 @@ public class Person {
 
     public Course getCourse() {
         return course;
+    }
+
+    public ApplicationStatus getApplicationStatus() {
+        return applicationStatus;
+    }
+
+    public InterviewStatus getInterviewStatus() {
+        return interviewStatus;
     }
 
     /**
@@ -100,13 +120,19 @@ public class Person {
                 && otherPerson.getPhone().equals(getPhone())
                 && otherPerson.getEmail().equals(getEmail())
                 && otherPerson.getCourse().equals(getCourse())
-                && otherPerson.getTags().equals(getTags());
+                && otherPerson.getTags().equals(getTags())
+                && otherPerson.getApplicationStatus().equals(getApplicationStatus())
+                && otherPerson.getInterviewStatus().equals(getInterviewStatus());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
+<<<<<<< HEAD
         return Objects.hash(studentId, name, phone, email, course, tags);
+=======
+        return Objects.hash(studentID, name, phone, email, course, tags, applicationStatus, interviewStatus);
+>>>>>>> origin/6869-add-status-attribute
     }
 
     @Override
@@ -127,6 +153,10 @@ public class Person {
             builder.append("; Tags: ");
             tags.forEach(builder::append);
         }
+        builder.append("; Application Status: ")
+                .append(getApplicationStatus());
+        builder.append("; Interview Status: ")
+                .append(getInterviewStatus());
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -6,8 +6,10 @@ import java.util.stream.Collectors;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.person.ApplicationStatus;
 import seedu.address.model.person.Course;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.InterviewStatus;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -18,8 +20,13 @@ import seedu.address.model.tag.Tag;
  * Contains utility methods for populating {@code AddressBook} with sample data.
  */
 public class SampleDataUtil {
+
+    private static final ApplicationStatus PENDING = new ApplicationStatus("pending");
+    private static final InterviewStatus INTERVIEW_PENDING = new InterviewStatus("pending");
+
     public static Person[] getSamplePersons() {
         return new Person[] {
+<<<<<<< HEAD
             new Person(new StudentId("E0123456"), new Name("Alex Yeoh"), new Phone("87438807"),
                 new Email("E0123456@u.nus.edu"), new Course("Business Analytics"), getTagSet("friends")),
             new Person(new StudentId("E0234567"), new Name("Bernice Yu"), new Phone("99272758"),
@@ -33,6 +40,26 @@ public class SampleDataUtil {
                 new Email("E0567890@u.nus.edu"), new Course("Information Systems"), getTagSet("classmates")),
             new Person(new StudentId("E0678901"), new Name("Roy Balakrishnan"), new Phone("92624417"),
                 new Email("E0678901@u.nus.edu"), new Course("Computer Science"), getTagSet("colleagues"))
+=======
+            new Person(new StudentID("E0123456"), new Name("Alex Yeoh"), new Phone("87438807"),
+                new Email("E0123456@u.nus.edu"), new Course("Business Analytics"),
+                    getTagSet("friends"), PENDING, INTERVIEW_PENDING),
+            new Person(new StudentID("E0234567"), new Name("Bernice Yu"), new Phone("99272758"),
+                new Email("E0234567@u.nus.edu"), new Course("Computer Engineering"),
+                getTagSet("colleagues", "friends"), PENDING, INTERVIEW_PENDING),
+            new Person(new StudentID("E0345678"), new Name("Charlotte Oliveiro"), new Phone("93210283"),
+                new Email("E0345678@u.nus.edu"), new Course("Computer Science"), getTagSet("neighbours"),
+                    PENDING, INTERVIEW_PENDING),
+            new Person(new StudentID("E0456789"), new Name("David Li"), new Phone("91031282"),
+                new Email("E0456789@u.nus.edu"), new Course("Information Security"), getTagSet("family"),
+                    PENDING, INTERVIEW_PENDING),
+            new Person(new StudentID("E0567890"), new Name("Irfan Ibrahim"), new Phone("92492021"),
+                new Email("E0567890@u.nus.edu"), new Course("Information Systems"), getTagSet("classmates"),
+                    PENDING, INTERVIEW_PENDING),
+            new Person(new StudentID("E0678901"), new Name("Roy Balakrishnan"), new Phone("92624417"),
+                new Email("E0678901@u.nus.edu"), new Course("Computer Science"), getTagSet("colleagues"),
+                    PENDING, INTERVIEW_PENDING)
+>>>>>>> origin/6869-add-status-attribute
         };
     }
 
@@ -51,6 +78,14 @@ public class SampleDataUtil {
         return Arrays.stream(strings)
                 .map(Tag::new)
                 .collect(Collectors.toSet());
+    }
+
+    public static ApplicationStatus getPending() {
+        return PENDING;
+    }
+
+    public static InterviewStatus getInterviewPending() {
+        return INTERVIEW_PENDING;
     }
 
 }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -26,40 +26,24 @@ public class SampleDataUtil {
 
     public static Person[] getSamplePersons() {
         return new Person[] {
-<<<<<<< HEAD
             new Person(new StudentId("E0123456"), new Name("Alex Yeoh"), new Phone("87438807"),
-                new Email("E0123456@u.nus.edu"), new Course("Business Analytics"), getTagSet("friends")),
-            new Person(new StudentId("E0234567"), new Name("Bernice Yu"), new Phone("99272758"),
-                new Email("E0234567@u.nus.edu"), new Course("Computer Engineering"),
-                getTagSet("colleagues", "friends")),
-            new Person(new StudentId("E0345678"), new Name("Charlotte Oliveiro"), new Phone("93210283"),
-                new Email("E0345678@u.nus.edu"), new Course("Computer Science"), getTagSet("neighbours")),
-            new Person(new StudentId("E0456789"), new Name("David Li"), new Phone("91031282"),
-                new Email("E0456789@u.nus.edu"), new Course("Information Security"), getTagSet("family")),
-            new Person(new StudentId("E0567890"), new Name("Irfan Ibrahim"), new Phone("92492021"),
-                new Email("E0567890@u.nus.edu"), new Course("Information Systems"), getTagSet("classmates")),
-            new Person(new StudentId("E0678901"), new Name("Roy Balakrishnan"), new Phone("92624417"),
-                new Email("E0678901@u.nus.edu"), new Course("Computer Science"), getTagSet("colleagues"))
-=======
-            new Person(new StudentID("E0123456"), new Name("Alex Yeoh"), new Phone("87438807"),
                 new Email("E0123456@u.nus.edu"), new Course("Business Analytics"),
                     getTagSet("friends"), PENDING, INTERVIEW_PENDING),
-            new Person(new StudentID("E0234567"), new Name("Bernice Yu"), new Phone("99272758"),
+            new Person(new StudentId("E0234567"), new Name("Bernice Yu"), new Phone("99272758"),
                 new Email("E0234567@u.nus.edu"), new Course("Computer Engineering"),
                 getTagSet("colleagues", "friends"), PENDING, INTERVIEW_PENDING),
-            new Person(new StudentID("E0345678"), new Name("Charlotte Oliveiro"), new Phone("93210283"),
+            new Person(new StudentId("E0345678"), new Name("Charlotte Oliveiro"), new Phone("93210283"),
                 new Email("E0345678@u.nus.edu"), new Course("Computer Science"), getTagSet("neighbours"),
                     PENDING, INTERVIEW_PENDING),
-            new Person(new StudentID("E0456789"), new Name("David Li"), new Phone("91031282"),
+            new Person(new StudentId("E0456789"), new Name("David Li"), new Phone("91031282"),
                 new Email("E0456789@u.nus.edu"), new Course("Information Security"), getTagSet("family"),
                     PENDING, INTERVIEW_PENDING),
-            new Person(new StudentID("E0567890"), new Name("Irfan Ibrahim"), new Phone("92492021"),
+            new Person(new StudentId("E0567890"), new Name("Irfan Ibrahim"), new Phone("92492021"),
                 new Email("E0567890@u.nus.edu"), new Course("Information Systems"), getTagSet("classmates"),
                     PENDING, INTERVIEW_PENDING),
-            new Person(new StudentID("E0678901"), new Name("Roy Balakrishnan"), new Phone("92624417"),
+            new Person(new StudentId("E0678901"), new Name("Roy Balakrishnan"), new Phone("92624417"),
                 new Email("E0678901@u.nus.edu"), new Course("Computer Science"), getTagSet("colleagues"),
                     PENDING, INTERVIEW_PENDING)
->>>>>>> origin/6869-add-status-attribute
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -43,15 +43,10 @@ class JsonAdaptedPerson {
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("studentId") String studentId, @JsonProperty("name") String name,
             @JsonProperty("phone") String phone, @JsonProperty("email") String email,
-<<<<<<< HEAD
-            @JsonProperty("course") String course, @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
-        this.studentId = studentId;
-=======
             @JsonProperty("course") String course, @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
             @JsonProperty("applicationStatus") String applicationStatus,
             @JsonProperty("interviewStatus") String interviewStatus) {
-        this.studentID = studentID;
->>>>>>> origin/6869-add-status-attribute
+        this.studentId = studentId;
         this.name = name;
         this.phone = phone;
         this.email = email;

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -11,8 +11,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.ApplicationStatus;
 import seedu.address.model.person.Course;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.InterviewStatus;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -32,6 +34,8 @@ class JsonAdaptedPerson {
     private final String email;
     private final String course;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
+    private final String applicationStatus;
+    private final String interviewStatus;
 
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
@@ -39,8 +43,15 @@ class JsonAdaptedPerson {
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("studentId") String studentId, @JsonProperty("name") String name,
             @JsonProperty("phone") String phone, @JsonProperty("email") String email,
+<<<<<<< HEAD
             @JsonProperty("course") String course, @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
         this.studentId = studentId;
+=======
+            @JsonProperty("course") String course, @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
+            @JsonProperty("applicationStatus") String applicationStatus,
+            @JsonProperty("interviewStatus") String interviewStatus) {
+        this.studentID = studentID;
+>>>>>>> origin/6869-add-status-attribute
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -48,6 +59,9 @@ class JsonAdaptedPerson {
         if (tagged != null) {
             this.tagged.addAll(tagged);
         }
+        this.applicationStatus = applicationStatus;
+        this.interviewStatus = interviewStatus;
+
     }
 
     /**
@@ -62,6 +76,8 @@ class JsonAdaptedPerson {
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
+        applicationStatus = source.getApplicationStatus().toString();
+        interviewStatus = source.getInterviewStatus().toString();
     }
 
     /**
@@ -117,6 +133,7 @@ class JsonAdaptedPerson {
         final Course modelCourse = new Course(course);
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelId, modelName, modelPhone, modelEmail, modelCourse, modelTags);
+        return new Person(modelId, modelName, modelPhone, modelEmail, modelCourse, modelTags,
+                new ApplicationStatus(applicationStatus), new InterviewStatus(interviewStatus));
     }
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -15,6 +15,9 @@ import seedu.address.model.person.Person;
 public class PersonCard extends UiPart<Region> {
 
     private static final String FXML = "PersonListCard.fxml";
+    private static final String APPLICATION_STATUS_MSG = "Application Status : ";
+    private static final String INTERVIEW_STATUS_MSG = "Interview Status : ";
+
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -39,8 +42,11 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label email;
     @FXML
+    private Label applicationStatus;
+    @FXML
+    private Label interviewStatus;
+    @FXML
     private FlowPane tags;
-
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
      */
@@ -55,6 +61,10 @@ public class PersonCard extends UiPart<Region> {
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+        applicationStatus.setText(APPLICATION_STATUS_MSG + person.getApplicationStatus().toString());
+        interviewStatus.setText(INTERVIEW_STATUS_MSG + person.getInterviewStatus().toString());
+
+
     }
 
     @Override

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -31,6 +31,8 @@
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="course" styleClass="cell_small_label" text="\$course" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <Label fx:id="applicationStatus" styleClass="cell_small_label" text="\$app_status" />
+      <Label fx:id="interviewStatus" styleClass="cell_small_label" text="\$interview_status" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -4,12 +4,16 @@
     "name": "Valid Person",
     "phone": "94824240",
     "email": "E0123456@u.nus.edu",
-    "course": "Computer Science"
+    "course": "Computer Science",
+    "applicationStatus" : "Pending",
+    "interviewStatus" : "Pending"
   }, {
     "studentId": "E0123456",
     "name": "Person With Invalid Phone Field",
     "phone": "948asdf2424",
     "email": "E0123456@u.nus.edu",
-    "course": "Computer Science"
+    "course": "Computer Science",
+    "applicationStatus" : "Pending",
+    "interviewStatus" : "Pending"
   } ]
 }

--- a/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
@@ -4,6 +4,8 @@
     "name": "Person with invalid name field: Ha!ns Mu@ster",
     "phone": "94824240",
     "email": "E0123456@u.nus.edu",
-    "course": "Computer Science"
+    "course": "Computer Science",
+    "applicationStatus" : "Pending",
+    "interviewStatus" : "Pending"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -5,12 +5,16 @@
     "phone": "94351253",
     "email": "E0123456@u.nus.edu",
     "course": "Business Analytics",
-    "tagged": [ "friends" ]
+    "tagged": [ "friends" ],
+    "applicationStatus" : "Pending",
+    "interviewStatus" : "Pending"
   }, {
     "studentId": "E0123456",
     "name": "Alice Pauline",
     "phone": "94351253",
     "email": "E0123456@u.nus.edu",
-    "course": "Business Analytics"
+    "course": "Business Analytics",
+    "applicationStatus" : "Pending",
+    "interviewStatus" : "Pending"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -3,6 +3,8 @@
     "name": "Hans Muster",
     "phone": "9482424",
     "email": "invalid@email!3e",
-    "address": "4th street"
+    "address": "4th street",
+    "applicationStatus" : "Pending",
+    "interviewStatus" : "Pending"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -6,48 +6,62 @@
     "phone" : "94351253",
     "email" : "E0123456@u.nus.edu",
     "course": "Business Analytics",
-    "tagged" : [ "friends" ]
+    "tagged" : [ "friends" ],
+    "applicationStatus" : "Pending",
+    "interviewStatus" : "Pending"
   }, {
     "studentId": "E0234567",
     "name" : "Benson Meier",
     "phone" : "98765432",
     "email" : "E0234567@u.nus.edu",
     "course": "Computer Engineering",
-    "tagged" : [ "owesMoney", "friends" ]
+    "tagged" : [ "owesMoney", "friends" ],
+    "applicationStatus" : "Pending",
+    "interviewStatus" : "Pending"
   }, {
     "studentId": "E0345678",
     "name" : "Carl Kurz",
     "phone" : "95352563",
     "email" : "E0345678@u.nus.edu",
     "course": "Computer Science",
-    "tagged" : [ ]
+    "tagged" : [ ],
+    "applicationStatus" : "Pending",
+    "interviewStatus" : "Pending"
   }, {
     "studentId": "E0456789",
     "name" : "Daniel Meier",
     "phone" : "87652533",
     "email" : "E0456789@u.nus.edu",
     "course": "Information Security",
-    "tagged" : [ "friends" ]
+    "tagged" : [ "friends" ],
+    "applicationStatus" : "Pending",
+    "interviewStatus" : "Pending"
   }, {
     "studentId": "E0567890",
     "name" : "Elle Meyer",
     "phone" : "94822240",
     "email" : "E0567890@u.nus.edu",
     "course": "Information Systems",
-    "tagged" : [ ]
+    "tagged" : [ ],
+    "applicationStatus" : "Pending",
+    "interviewStatus" : "Pending"
   }, {
     "studentId": "E0678901",
     "name" : "Fiona Kunz",
     "phone" : "94824270",
     "email" : "E0678901@u.nus.edu",
     "course": "Business Analytics",
-    "tagged" : [ ]
+    "tagged" : [ ],
+    "applicationStatus" : "Pending",
+    "interviewStatus" : "Pending"
   }, {
     "studentId": "E0789012",
     "name" : "George Best",
     "phone" : "94824420",
     "email" : "E0789012@u.nus.edu",
     "course": "Computer Engineering",
-    "tagged" : [ ]
+    "tagged" : [ ],
+    "applicationStatus" : "Pending",
+    "interviewStatus" : "Pending"
   } ]
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -79,9 +79,10 @@ public class LogicManagerTest {
         logic = new LogicManager(model, storage);
 
         // Execute add command
-        String addCommand = AddCommand.COMMAND_WORD + STUDENT_ID_DESC_AMY + NAME_DESC_AMY + PHONE_DESC_AMY
-                + COURSE_DESC_AMY;
-        Person expectedPerson = new PersonBuilder(AMY).withTags().build();
+        String addCommand = AddCommand.COMMAND_WORD + STUDENT_ID_DESC_AMY + NAME_DESC_AMY
+                + PHONE_DESC_AMY + COURSE_DESC_AMY;
+        Person expectedPerson = new PersonBuilder(AMY).withTags()
+                .withApplicationStatus("Pending").withInterviewStatus("Pending").build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addPerson(expectedPerson);
         String expectedMessage = LogicManager.FILE_OPS_ERROR_MESSAGE + DUMMY_IO_EXCEPTION;

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -2,9 +2,11 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPLICATION_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -39,6 +41,8 @@ public class CommandTestUtil {
     public static final String VALID_COURSE_BOB = "Computer Engineering";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_APPLICATION_STATUS = "Pending";
+    public static final String VALID_INTERVIEW_STATUS = "Pending";
 
     public static final String STUDENT_ID_DESC_AMY = " " + PREFIX_ID + VALID_STUDENT_ID_AMY;
     public static final String STUDENT_ID_DESC_BOB = " " + PREFIX_ID + VALID_STUDENT_ID_BOB;
@@ -52,6 +56,8 @@ public class CommandTestUtil {
     public static final String COURSE_DESC_BOB = " " + PREFIX_COURSE + VALID_COURSE_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
+    public static final String APPLICATION_STATUS_PENDING = " " + PREFIX_APPLICATION_STATUS + VALID_APPLICATION_STATUS;
+    public static final String INTERVIEW_STATUS_PENDING = " " + PREFIX_INTERVIEW_STATUS + VALID_INTERVIEW_STATUS;
 
     public static final String INVALID_STUDENT_ID_DESC = " " + PREFIX_ID + "A0123456"; // Must begin with 'E'
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
@@ -69,10 +75,17 @@ public class CommandTestUtil {
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withStudentId(VALID_STUDENT_ID_AMY).withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withCourse(VALID_COURSE_AMY)
+<<<<<<< HEAD
                 .withTags(VALID_TAG_FRIEND).build();
         DESC_BOB = new EditPersonDescriptorBuilder().withStudentId(VALID_STUDENT_ID_BOB).withName(VALID_NAME_BOB)
+=======
+                .withTags(VALID_TAG_FRIEND).withApplicationStatus(APPLICATION_STATUS_PENDING)
+                .withInterviewStatus(INTERVIEW_STATUS_PENDING).build();
+        DESC_BOB = new EditPersonDescriptorBuilder().withStudentID(VALID_STUDENT_ID_BOB).withName(VALID_NAME_BOB)
+>>>>>>> origin/6869-add-status-attribute
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withCourse(VALID_COURSE_BOB)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).withApplicationStatus(APPLICATION_STATUS_PENDING)
+                .withInterviewStatus(INTERVIEW_STATUS_PENDING).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -75,14 +75,9 @@ public class CommandTestUtil {
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withStudentId(VALID_STUDENT_ID_AMY).withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withCourse(VALID_COURSE_AMY)
-<<<<<<< HEAD
-                .withTags(VALID_TAG_FRIEND).build();
-        DESC_BOB = new EditPersonDescriptorBuilder().withStudentId(VALID_STUDENT_ID_BOB).withName(VALID_NAME_BOB)
-=======
                 .withTags(VALID_TAG_FRIEND).withApplicationStatus(APPLICATION_STATUS_PENDING)
                 .withInterviewStatus(INTERVIEW_STATUS_PENDING).build();
-        DESC_BOB = new EditPersonDescriptorBuilder().withStudentID(VALID_STUDENT_ID_BOB).withName(VALID_NAME_BOB)
->>>>>>> origin/6869-add-status-attribute
+        DESC_BOB = new EditPersonDescriptorBuilder().withStudentId(VALID_STUDENT_ID_BOB).withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withCourse(VALID_COURSE_BOB)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).withApplicationStatus(APPLICATION_STATUS_PENDING)
                 .withInterviewStatus(INTERVIEW_STATUS_PENDING).build();

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -43,7 +43,8 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() {
-        Person expectedPerson = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
+        Person expectedPerson = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND)
+                .withApplicationStatus("Pending").withInterviewStatus("Pending").build();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + STUDENT_ID_DESC_BOB + NAME_DESC_BOB + PHONE_DESC_BOB
@@ -61,13 +62,15 @@ public class AddCommandParserTest {
         Person expectedPersonMultipleTags = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
                 .build();
         assertParseSuccess(parser, STUDENT_ID_DESC_BOB + NAME_DESC_BOB + PHONE_DESC_BOB
-                + COURSE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddCommand(expectedPersonMultipleTags));
+                + COURSE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                new AddCommand(expectedPersonMultipleTags));
     }
 
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero tags
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
+
         assertParseSuccess(parser, STUDENT_ID_DESC_AMY + NAME_DESC_AMY + PHONE_DESC_AMY
                 + COURSE_DESC_AMY, new AddCommand(expectedPerson));
     }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -1,10 +1,12 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.APPLICATION_STATUS_PENDING;
 import static seedu.address.logic.commands.CommandTestUtil.COURSE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.COURSE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.INTERVIEW_STATUS_PENDING;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
@@ -122,10 +124,11 @@ public class EditCommandParserTest {
     @Test
     public void parse_someFieldsSpecified_success() {
         Index targetIndex = INDEX_FIRST_PERSON;
-        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
+        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY + APPLICATION_STATUS_PENDING
+                + INTERVIEW_STATUS_PENDING;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)
-                .withEmail(VALID_EMAIL_AMY).build();
+                .withEmail(VALID_EMAIL_AMY).withApplicationStatus("Pending").withInterviewStatus("Pending").build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -3,7 +3,9 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPLICATION_STATUS;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COURSE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INTERVIEW_STATUS;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
@@ -47,6 +49,8 @@ public class AddressBookTest {
     public void resetData_withDuplicatePersons_throwsDuplicatePersonException() {
         // Two persons with the same identity fields
         Person editedAlice = new PersonBuilder(ALICE).withCourse(VALID_COURSE_BOB).withTags(VALID_TAG_HUSBAND)
+                .withApplicationStatus(VALID_APPLICATION_STATUS)
+                .withInterviewStatus(VALID_INTERVIEW_STATUS)
                 .build();
         List<Person> newPersons = Arrays.asList(ALICE, editedAlice);
         AddressBookStub newData = new AddressBookStub(newPersons);

--- a/src/test/java/seedu/address/model/person/ApplicationStatusTest.java
+++ b/src/test/java/seedu/address/model/person/ApplicationStatusTest.java
@@ -1,0 +1,36 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class ApplicationStatusTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new ApplicationStatus(null));
+    }
+
+    @Test
+    public void isValidStatus() {
+        assertThrows(NullPointerException.class, () -> ApplicationStatus.isValidStatus(null));
+
+        //wrong format
+        assertFalse(ApplicationStatus.isValidStatus(""));
+        assertFalse(ApplicationStatus.isValidStatus(" "));
+        assertFalse(ApplicationStatus.isValidStatus("accepts"));
+        assertFalse(ApplicationStatus.isValidStatus("rejects"));
+        assertFalse(ApplicationStatus.isValidStatus("denied"));
+
+        //correct format
+        assertTrue(ApplicationStatus.isValidStatus("accepted"));
+        assertTrue(ApplicationStatus.isValidStatus("Accepted"));
+        assertTrue(ApplicationStatus.isValidStatus("Rejected"));
+        assertTrue(ApplicationStatus.isValidStatus("rejected"));
+        assertTrue(ApplicationStatus.isValidStatus("Pending"));
+        assertTrue(ApplicationStatus.isValidStatus("pending"));
+    }
+
+}

--- a/src/test/java/seedu/address/model/person/InterviewStatusTest.java
+++ b/src/test/java/seedu/address/model/person/InterviewStatusTest.java
@@ -1,0 +1,41 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class InterviewStatusTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new InterviewStatus(null));
+    }
+
+    @Test
+    public void isValidStatus() {
+        assertThrows(NullPointerException.class, () -> InterviewStatus.isValidStatus(null));
+
+        assertFalse(InterviewStatus.isValidStatus(""));
+        assertFalse(InterviewStatus.isValidStatus(" "));
+        assertFalse(InterviewStatus.isValidStatus("interviews"));
+        assertFalse(InterviewStatus.isValidStatus("interviewe"));
+        assertFalse(InterviewStatus.isValidStatus("not interview"));
+        assertFalse(InterviewStatus.isValidStatus("pend"));
+
+
+        assertTrue(InterviewStatus.isValidStatus("interviewing"));
+        assertTrue(InterviewStatus.isValidStatus("Interviewing"));
+        assertTrue(InterviewStatus.isValidStatus("not interviewed"));
+        assertTrue(InterviewStatus.isValidStatus("Not Interviewed"));
+        assertTrue(InterviewStatus.isValidStatus("Not interviewed"));
+        assertTrue(InterviewStatus.isValidStatus("not Interviewed"));
+        assertTrue(InterviewStatus.isValidStatus("notinterviewed"));
+        assertTrue(InterviewStatus.isValidStatus("NotInterviewed"));
+        assertTrue(InterviewStatus.isValidStatus("Notinterviewed"));
+        assertTrue(InterviewStatus.isValidStatus("notInterviewed"));
+        assertTrue(InterviewStatus.isValidStatus("pending"));
+        assertTrue(InterviewStatus.isValidStatus("Pending"));
+    }
+}

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -46,28 +46,17 @@ public class JsonAdaptedPersonTest {
 
     @Test
     public void toModelType_invalidStudentId_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_STUDENT_ID, VALID_NAME, VALID_PHONE,
-<<<<<<< HEAD
-                        VALID_EMAIL, VALID_COURSE, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(INVALID_STUDENT_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                VALID_COURSE, VALID_TAGS, VALID_APPLICATION_STATUS, VALID_INTERVIEW_STATUS);
         String expectedMessage = StudentId.MESSAGE_CONSTRAINTS;
-=======
-                        VALID_EMAIL, VALID_COURSE, VALID_TAGS, VALID_APPLICATION_STATUS, VALID_INTERVIEW_STATUS);
-        String expectedMessage = StudentID.MESSAGE_CONSTRAINTS;
->>>>>>> origin/6869-add-status-attribute
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullStudentId_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_NAME, VALID_PHONE,
-<<<<<<< HEAD
-                VALID_EMAIL, VALID_COURSE, VALID_TAGS);
-        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, StudentId.class.getSimpleName());
-=======
                 VALID_EMAIL, VALID_COURSE, VALID_TAGS, VALID_APPLICATION_STATUS, VALID_INTERVIEW_STATUS);
-        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, StudentID.class.getSimpleName());
->>>>>>> origin/6869-add-status-attribute
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, StudentId.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -12,8 +12,10 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.person.ApplicationStatus;
 import seedu.address.model.person.Course;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.InterviewStatus;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.StudentId;
@@ -30,6 +32,8 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_COURSE = BENSON.getCourse().toString();
+    private static final String VALID_APPLICATION_STATUS = new ApplicationStatus("Pending").toString();
+    private static final String VALID_INTERVIEW_STATUS = new InterviewStatus("Pending").toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -44,16 +48,26 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidStudentId_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_STUDENT_ID, VALID_NAME, VALID_PHONE,
+<<<<<<< HEAD
                         VALID_EMAIL, VALID_COURSE, VALID_TAGS);
         String expectedMessage = StudentId.MESSAGE_CONSTRAINTS;
+=======
+                        VALID_EMAIL, VALID_COURSE, VALID_TAGS, VALID_APPLICATION_STATUS, VALID_INTERVIEW_STATUS);
+        String expectedMessage = StudentID.MESSAGE_CONSTRAINTS;
+>>>>>>> origin/6869-add-status-attribute
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullStudentId_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_NAME, VALID_PHONE,
+<<<<<<< HEAD
                 VALID_EMAIL, VALID_COURSE, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, StudentId.class.getSimpleName());
+=======
+                VALID_EMAIL, VALID_COURSE, VALID_TAGS, VALID_APPLICATION_STATUS, VALID_INTERVIEW_STATUS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, StudentID.class.getSimpleName());
+>>>>>>> origin/6869-add-status-attribute
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
@@ -61,7 +75,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_STUDENT_ID, INVALID_NAME, VALID_PHONE,
-                        VALID_EMAIL, VALID_COURSE, VALID_TAGS);
+                        VALID_EMAIL, VALID_COURSE, VALID_TAGS, VALID_APPLICATION_STATUS, VALID_INTERVIEW_STATUS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -69,7 +83,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_STUDENT_ID, null, VALID_PHONE,
-                VALID_EMAIL, VALID_COURSE, VALID_TAGS);
+                VALID_EMAIL, VALID_COURSE, VALID_TAGS, VALID_APPLICATION_STATUS, VALID_INTERVIEW_STATUS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -78,7 +92,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_STUDENT_ID, VALID_NAME, INVALID_PHONE,
-                        VALID_EMAIL, VALID_COURSE, VALID_TAGS);
+                        VALID_EMAIL, VALID_COURSE, VALID_TAGS, VALID_APPLICATION_STATUS, VALID_INTERVIEW_STATUS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -86,7 +100,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_STUDENT_ID, VALID_NAME, null,
-                VALID_EMAIL, VALID_COURSE, VALID_TAGS);
+                VALID_EMAIL, VALID_COURSE, VALID_TAGS, VALID_APPLICATION_STATUS, VALID_INTERVIEW_STATUS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -95,7 +109,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_STUDENT_ID, VALID_NAME, VALID_PHONE,
-                        INVALID_EMAIL, VALID_COURSE, VALID_TAGS);
+                        INVALID_EMAIL, VALID_COURSE, VALID_TAGS, VALID_APPLICATION_STATUS, VALID_INTERVIEW_STATUS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -103,7 +117,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_STUDENT_ID, VALID_NAME, VALID_PHONE,
-                null, VALID_COURSE, VALID_TAGS);
+                null, VALID_COURSE, VALID_TAGS, VALID_APPLICATION_STATUS, VALID_INTERVIEW_STATUS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -114,14 +128,14 @@ public class JsonAdaptedPersonTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_STUDENT_ID, VALID_NAME, VALID_PHONE,
-                        VALID_EMAIL, VALID_COURSE, invalidTags);
+                        VALID_EMAIL, VALID_COURSE, invalidTags, VALID_APPLICATION_STATUS, VALID_INTERVIEW_STATUS);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
     @Test
     public void toModelType_nullCourse_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_STUDENT_ID, VALID_NAME, VALID_PHONE,
-                VALID_EMAIL, null, VALID_TAGS);
+                VALID_EMAIL, null, VALID_TAGS, VALID_APPLICATION_STATUS, VALID_INTERVIEW_STATUS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Course.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -5,8 +5,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.model.person.ApplicationStatus;
 import seedu.address.model.person.Course;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.InterviewStatus;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -39,6 +41,8 @@ public class EditPersonDescriptorBuilder {
         descriptor.setEmail(person.getEmail());
         descriptor.setCourse(person.getCourse());
         descriptor.setTags(person.getTags());
+        descriptor.setApplicationStatus(person.getApplicationStatus());
+        descriptor.setInterviewStatus(person.getInterviewStatus());
     }
 
     /**
@@ -93,5 +97,21 @@ public class EditPersonDescriptorBuilder {
 
     public EditPersonDescriptor build() {
         return descriptor;
+    }
+
+    /**
+     * Sets the {@code ApplicationStatus} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withApplicationStatus(String applicationStatus) {
+        descriptor.setApplicationStatus(new ApplicationStatus(applicationStatus));
+        return this;
+    }
+
+    /**
+     * Sets the {@code InterviewStatus} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withInterviewStatus(String interviewStatus) {
+        descriptor.setInterviewStatus(new InterviewStatus(interviewStatus));
+        return this;
     }
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -129,11 +129,7 @@ public class PersonBuilder {
     }
 
     public Person build() {
-<<<<<<< HEAD
-        return new Person(studentId, name, phone, email, course, tags);
-=======
-        return new Person(studentID, name, phone, email, course, tags, applicationStatus, interviewStatus);
->>>>>>> origin/6869-add-status-attribute
+        return new Person(studentId, name, phone, email, course, tags, applicationStatus, interviewStatus);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -3,8 +3,10 @@ package seedu.address.testutil;
 import java.util.HashSet;
 import java.util.Set;
 
+import seedu.address.model.person.ApplicationStatus;
 import seedu.address.model.person.Course;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.InterviewStatus;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -22,6 +24,8 @@ public class PersonBuilder {
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "E0123456@u.nus.edu";
     public static final String DEFAULT_COURSE = "Computer Science";
+    public static final String DEFAULT_APPLICATION_STATUS = "Pending";
+    public static final String DEFAULT_INTERVIEW_STATUS = "Pending";
 
     private StudentId studentId;
     private Name name;
@@ -29,6 +33,8 @@ public class PersonBuilder {
     private Email email;
     private Course course;
     private Set<Tag> tags;
+    private ApplicationStatus applicationStatus;
+    private InterviewStatus interviewStatus;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -40,6 +46,8 @@ public class PersonBuilder {
         email = new Email(DEFAULT_EMAIL);
         course = new Course(DEFAULT_COURSE);
         tags = new HashSet<>();
+        applicationStatus = new ApplicationStatus(DEFAULT_APPLICATION_STATUS);
+        interviewStatus = new InterviewStatus(DEFAULT_INTERVIEW_STATUS);
     }
 
     /**
@@ -52,6 +60,8 @@ public class PersonBuilder {
         email = personToCopy.getEmail();
         course = personToCopy.getCourse();
         tags = new HashSet<>(personToCopy.getTags());
+        applicationStatus = personToCopy.getApplicationStatus();
+        interviewStatus = personToCopy.getInterviewStatus();
     }
 
     /**
@@ -102,8 +112,28 @@ public class PersonBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code Application Status} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withApplicationStatus(String applicationStatus) {
+        this.applicationStatus = new ApplicationStatus(applicationStatus);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Interview Status} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withInterviewStatus(String interviewStatus) {
+        this.interviewStatus = new InterviewStatus(interviewStatus);
+        return this;
+    }
+
     public Person build() {
+<<<<<<< HEAD
         return new Person(studentId, name, phone, email, course, tags);
+=======
+        return new Person(studentID, name, phone, email, course, tags, applicationStatus, interviewStatus);
+>>>>>>> origin/6869-add-status-attribute
     }
 
 }

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -1,8 +1,10 @@
 package seedu.address.testutil;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPLICATION_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -13,6 +15,8 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
+
+
 
 /**
  * A utility class for Person.
@@ -51,14 +55,21 @@ public class PersonUtil {
         descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
         descriptor.getCourse().ifPresent(course -> sb.append(PREFIX_COURSE).append(course.course).append(" "));
+
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {
-                sb.append(PREFIX_TAG);
+                sb.append(PREFIX_TAG).append(" ");
             } else {
                 tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
             }
         }
+
+        descriptor.getApplicationStatus().ifPresent(applicationStatus -> sb.append(PREFIX_APPLICATION_STATUS)
+                .append(applicationStatus.toString()).append(" "));
+        descriptor.getInterviewStatus().ifPresent(interviewStatus -> sb.append(PREFIX_INTERVIEW_STATUS)
+                .append(interviewStatus.toString()).append(" "));
+
         return sb.toString();
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -1,9 +1,11 @@
 package seedu.address.testutil;
 
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPLICATION_STATUS;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COURSE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COURSE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INTERVIEW_STATUS;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
@@ -32,6 +34,8 @@ public class TypicalPersons {
             .withEmail("E0123456@u.nus.edu")
             .withCourse("Business Analytics")
             .withTags("friends")
+            .withApplicationStatus(VALID_APPLICATION_STATUS)
+            .withInterviewStatus(VALID_INTERVIEW_STATUS)
             .build();
     public static final Person BENSON = new PersonBuilder()
             .withStudentId("E0234567")
@@ -40,6 +44,8 @@ public class TypicalPersons {
             .withEmail("E0234567@u.nus.edu")
             .withCourse("Computer Engineering")
             .withTags("owesMoney", "friends")
+            .withApplicationStatus(VALID_APPLICATION_STATUS)
+            .withInterviewStatus(VALID_INTERVIEW_STATUS)
             .build();
     public static final Person CARL = new PersonBuilder()
             .withStudentId("E0345678")
@@ -47,6 +53,8 @@ public class TypicalPersons {
             .withPhone("95352563")
             .withEmail("E0345678@u.nus.edu")
             .withCourse("Computer Science")
+            .withApplicationStatus(VALID_APPLICATION_STATUS)
+            .withInterviewStatus(VALID_INTERVIEW_STATUS)
             .build();
     public static final Person DANIEL = new PersonBuilder()
             .withStudentId("E0456789")
@@ -55,6 +63,8 @@ public class TypicalPersons {
             .withEmail("E0456789@u.nus.edu")
             .withCourse("Information Security")
             .withTags("friends")
+            .withApplicationStatus(VALID_APPLICATION_STATUS)
+            .withInterviewStatus(VALID_INTERVIEW_STATUS)
             .build();
     public static final Person ELLE = new PersonBuilder()
             .withStudentId("E0567890")
@@ -62,6 +72,8 @@ public class TypicalPersons {
             .withPhone("94822240")
             .withEmail("E0567890@u.nus.edu")
             .withCourse("Information Systems")
+            .withApplicationStatus(VALID_APPLICATION_STATUS)
+            .withInterviewStatus(VALID_INTERVIEW_STATUS)
             .build();
     public static final Person FIONA = new PersonBuilder()
             .withStudentId("E0678901")
@@ -69,6 +81,8 @@ public class TypicalPersons {
             .withPhone("94824270")
             .withEmail("E0678901@u.nus.edu")
             .withCourse("Business Analytics")
+            .withApplicationStatus(VALID_APPLICATION_STATUS)
+            .withInterviewStatus(VALID_INTERVIEW_STATUS)
             .build();
     public static final Person GEORGE = new PersonBuilder()
             .withStudentId("E0789012")
@@ -76,6 +90,8 @@ public class TypicalPersons {
             .withPhone("94824420")
             .withEmail("E0789012@u.nus.edu")
             .withCourse("Computer Engineering")
+            .withApplicationStatus(VALID_APPLICATION_STATUS)
+            .withInterviewStatus(VALID_INTERVIEW_STATUS)
             .build();
 
     // Manually added
@@ -85,6 +101,8 @@ public class TypicalPersons {
             .withPhone("84824240")
             .withEmail("E0890123@u.nus.edu")
             .withCourse("Computer Science")
+            .withApplicationStatus(VALID_APPLICATION_STATUS)
+            .withInterviewStatus(VALID_INTERVIEW_STATUS)
             .build();
     public static final Person IDA = new PersonBuilder()
             .withStudentId("E0901234")
@@ -92,6 +110,8 @@ public class TypicalPersons {
             .withPhone("84821310")
             .withEmail("E0901234@u.nus.edu")
             .withCourse("Information Security")
+            .withApplicationStatus(VALID_APPLICATION_STATUS)
+            .withInterviewStatus(VALID_INTERVIEW_STATUS)
             .build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
@@ -102,6 +122,8 @@ public class TypicalPersons {
             .withEmail(VALID_EMAIL_AMY)
             .withCourse(VALID_COURSE_AMY)
             .withTags(VALID_TAG_FRIEND)
+            .withApplicationStatus(VALID_APPLICATION_STATUS)
+            .withInterviewStatus(VALID_INTERVIEW_STATUS)
             .build();
     public static final Person BOB = new PersonBuilder()
             .withStudentId(VALID_STUDENT_ID_BOB)
@@ -110,6 +132,8 @@ public class TypicalPersons {
             .withEmail(VALID_EMAIL_BOB)
             .withCourse(VALID_COURSE_BOB)
             .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+            .withApplicationStatus(VALID_APPLICATION_STATUS)
+            .withInterviewStatus(VALID_INTERVIEW_STATUS)
             .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER


### PR DESCRIPTION
Currently the candidates do not have statuses tagged to them. 

Let's add new attributes into the Candidate  
- ApplicationStatus
- InterviewStatus

Currently no new changes in the workflow (i.e. adding a new user will not require new commands), default values for new Candidates will be `pending` for both `ApplicationStatus` and `InterviewStatus`. The UI to display the statuses of the candidate as well. 