### PR TITLE
Create trigger for `ApplicationStatus`

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -293,9 +293,10 @@ public class EditCommand extends Command {
          * Allows the {@code InterviewStatus} to be triggered by ApplicationStatus.
          */
         public void triggerInterviewStatus(ApplicationStatus applicationStatus) {
-            String acceptedTrigger = "Accepted";
-            String rejectedTrigger = "Rejected";
-            String executedTrigger = "Completed";
+            String acceptedTrigger = ApplicationStatus.ACCEPTED_STATUS;
+            String rejectedTrigger = ApplicationStatus.REJECTED_STATUS;
+            String executedTrigger = InterviewStatus.COMPLETED;
+
             if (getApplicationStatus().isPresent()) {
                 if (applicationStatus.toString().equals(acceptedTrigger)
                         || applicationStatus.toString().equals(rejectedTrigger)) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -222,6 +222,7 @@ public class EditCommand extends Command {
 
         public void setApplicationStatus(ApplicationStatus applicationStatus) {
             this.applicationStatus = applicationStatus;
+            triggerInterviewStatus(applicationStatus);
         }
 
         public Optional<ApplicationStatus> getApplicationStatus() {
@@ -285,6 +286,22 @@ public class EditCommand extends Command {
                     && getApplicationStatus().equals(e.getApplicationStatus())
                     && getInterviewStatus().equals(e.getInterviewStatus())
                     && getAvailability().equals(e.getAvailability());
+        }
+
+
+        /**
+         * Allows the {@code InterviewStatus} to be triggered by ApplicationStatus.
+         */
+        public void triggerInterviewStatus(ApplicationStatus applicationStatus) {
+            String acceptedTrigger = "Accepted";
+            String rejectedTrigger = "Rejected";
+            String executedTrigger = "Completed";
+            if (getApplicationStatus().isPresent()) {
+                if (applicationStatus.toString().equals(acceptedTrigger)
+                        || applicationStatus.toString().equals(rejectedTrigger)) {
+                    setInterviewStatus(new InterviewStatus(executedTrigger));
+                }
+            }
         }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -10,6 +10,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.candidate.ApplicationStatus.ACCEPTED_STATUS;
+import static seedu.address.model.candidate.ApplicationStatus.REJECTED_STATUS;
+import static seedu.address.model.candidate.InterviewStatus.COMPLETED;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -293,14 +296,10 @@ public class EditCommand extends Command {
          * Allows the {@code InterviewStatus} to be triggered by ApplicationStatus.
          */
         public void triggerInterviewStatus(ApplicationStatus applicationStatus) {
-            String acceptedTrigger = ApplicationStatus.ACCEPTED_STATUS;
-            String rejectedTrigger = ApplicationStatus.REJECTED_STATUS;
-            String executedTrigger = InterviewStatus.COMPLETED;
-
             if (getApplicationStatus().isPresent()) {
-                if (applicationStatus.toString().equals(acceptedTrigger)
-                        || applicationStatus.toString().equals(rejectedTrigger)) {
-                    setInterviewStatus(new InterviewStatus(executedTrigger));
+                if (applicationStatus.toString().equals(ACCEPTED_STATUS)
+                        || applicationStatus.toString().equals(REJECTED_STATUS)) {
+                    setInterviewStatus(new InterviewStatus(COMPLETED));
                 }
             }
         }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -8,8 +8,8 @@ import static seedu.address.logic.commands.CommandTestUtil.COURSE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.STUDENT_ID_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_APPLICATION_STATUS;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_INTERVIEW_STATUS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPLICATION_PENDING;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INTERVIEW_NOT_SCHEDULED;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.AMY;
 
@@ -92,7 +92,8 @@ public class LogicManagerTest {
         String addCommand = AddCommand.COMMAND_WORD + STUDENT_ID_DESC_AMY + NAME_DESC_AMY
                 + PHONE_DESC_AMY + COURSE_DESC_AMY + AVAILABILITY_DESC_AMY;
         Candidate expectedCandidate = new CandidateBuilder(AMY).withTags()
-                .withApplicationStatus(VALID_APPLICATION_STATUS).withInterviewStatus(VALID_INTERVIEW_STATUS).build();
+                .withApplicationStatus(VALID_APPLICATION_PENDING)
+                .withInterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED).build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addPerson(expectedCandidate);
         String expectedMessage = LogicManager.FILE_OPS_ERROR_MESSAGE + DUMMY_IO_EXCEPTION;

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -45,8 +45,12 @@ public class CommandTestUtil {
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
-    public static final String VALID_APPLICATION_STATUS = "Pending";
-    public static final String VALID_INTERVIEW_STATUS = "Not Scheduled";
+    public static final String VALID_APPLICATION_PENDING = "Pending";
+    public static final String VALID_APPLICATION_REJECTED = "Rejected";
+    public static final String VALID_APPLICATION_ACCEPTED = "Accepted";
+    public static final String VALID_INTERVIEW_SCHEDULED = "Scheduled";
+    public static final String VALID_INTERVIEW_COMPLETED = "Completed";
+    public static final String VALID_INTERVIEW_NOT_SCHEDULED = "Not Scheduled";
     public static final String VALID_AVAILABILITY_AMY = "1,2,3,4,5";
     public static final String VALID_AVAILABILITY_BOB = "1,2,6,7";
 
@@ -70,8 +74,8 @@ public class CommandTestUtil {
     public static final String COURSE_DESC_BOB = " " + PREFIX_COURSE + VALID_COURSE_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
-    public static final String APPLICATION_STATUS_PENDING = " " + PREFIX_APPLICATION_STATUS + VALID_APPLICATION_STATUS;
-    public static final String INTERVIEW_STATUS_PENDING = " " + PREFIX_INTERVIEW_STATUS + VALID_INTERVIEW_STATUS;
+    public static final String APPLICATION_STATUS_PENDING = " " + PREFIX_APPLICATION_STATUS + VALID_APPLICATION_PENDING;
+    public static final String INTERVIEW_STATUS_PENDING = " " + PREFIX_INTERVIEW_STATUS + VALID_INTERVIEW_NOT_SCHEDULED;
     public static final String AVAILABILITY_DESC_AMY = " " + PREFIX_AVAILABILITY + VALID_AVAILABILITY_AMY;
     public static final String AVAILABILITY_DESC_BOB = " " + PREFIX_AVAILABILITY + VALID_AVAILABILITY_BOB;
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -1,9 +1,14 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPLICATION_ACCEPTED;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPLICATION_PENDING;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INTERVIEW_COMPLETED;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INTERVIEW_NOT_SCHEDULED;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
@@ -25,7 +30,9 @@ import seedu.address.model.InterviewSchedule;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.candidate.ApplicationStatus;
 import seedu.address.model.candidate.Candidate;
+import seedu.address.model.candidate.InterviewStatus;
 import seedu.address.testutil.CandidateBuilder;
 import seedu.address.testutil.EditCandidateDescriptorBuilder;
 
@@ -149,6 +156,25 @@ public class EditCommandTest {
                 new EditCandidateDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_trigger_success() {
+        EditPersonDescriptor editPersonDescriptor = new EditCandidateDescriptorBuilder()
+                .withName(VALID_NAME_BOB)
+                .withApplicationStatus(VALID_APPLICATION_PENDING)
+                .withInterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED)
+                .build();
+        assertEquals(editPersonDescriptor.getApplicationStatus().get(),
+                new ApplicationStatus(VALID_APPLICATION_PENDING));
+        assertEquals(editPersonDescriptor.getInterviewStatus().get(),
+                new InterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED));
+
+        editPersonDescriptor.setApplicationStatus(new ApplicationStatus(VALID_APPLICATION_ACCEPTED));
+        assertEquals(editPersonDescriptor.getApplicationStatus().get(),
+                new ApplicationStatus(VALID_APPLICATION_ACCEPTED));
+        assertEquals(editPersonDescriptor.getInterviewStatus().get(),
+                new InterviewStatus(VALID_INTERVIEW_COMPLETED));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -21,9 +21,9 @@ import static seedu.address.logic.commands.CommandTestUtil.STUDENT_ID_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.STUDENT_ID_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_APPLICATION_STATUS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPLICATION_PENDING;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COURSE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_INTERVIEW_STATUS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INTERVIEW_NOT_SCHEDULED;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
@@ -50,7 +50,8 @@ public class AddCommandParserTest {
     @Test
     public void parse_allFieldsPresent_success() {
         Candidate expectedCandidate = new CandidateBuilder(BOB).withTags(VALID_TAG_FRIEND)
-                .withApplicationStatus(VALID_APPLICATION_STATUS).withInterviewStatus(VALID_INTERVIEW_STATUS).build();
+                .withApplicationStatus(VALID_APPLICATION_PENDING)
+                .withInterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED).build();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + STUDENT_ID_DESC_BOB + NAME_DESC_BOB + PHONE_DESC_BOB

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -19,14 +19,14 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_APPLICATION_STATUS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPLICATION_PENDING;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_AVAILABILITY_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_AVAILABILITY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COURSE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COURSE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_INTERVIEW_STATUS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INTERVIEW_NOT_SCHEDULED;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
@@ -134,8 +134,8 @@ public class EditCommandParserTest {
                 + INTERVIEW_STATUS_PENDING;
 
         EditPersonDescriptor descriptor = new EditCandidateDescriptorBuilder().withPhone(VALID_PHONE_BOB)
-                .withEmail(VALID_EMAIL_AMY).withApplicationStatus(VALID_APPLICATION_STATUS)
-                .withInterviewStatus(VALID_INTERVIEW_STATUS).build();
+                .withEmail(VALID_EMAIL_AMY).withApplicationStatus(VALID_APPLICATION_PENDING)
+                .withInterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -3,10 +3,10 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_APPLICATION_STATUS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPLICATION_PENDING;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_AVAILABILITY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COURSE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_INTERVIEW_STATUS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INTERVIEW_NOT_SCHEDULED;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
@@ -52,8 +52,8 @@ public class AddressBookTest {
     public void resetData_withDuplicatePersons_throwsDuplicatePersonException() {
         // Two persons with the same identity fields
         Candidate editedAlice = new CandidateBuilder(ALICE).withCourse(VALID_COURSE_BOB).withTags(VALID_TAG_HUSBAND)
-                .withApplicationStatus(VALID_APPLICATION_STATUS)
-                .withInterviewStatus(VALID_INTERVIEW_STATUS)
+                .withApplicationStatus(VALID_APPLICATION_PENDING)
+                .withInterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED)
                 .withAvailability(VALID_AVAILABILITY_BOB)
                 .build();
         List<Candidate> newCandidates = Arrays.asList(ALICE, editedAlice);

--- a/src/test/java/seedu/address/model/candidate/ApplicationStatusTest.java
+++ b/src/test/java/seedu/address/model/candidate/ApplicationStatusTest.java
@@ -1,7 +1,11 @@
 package seedu.address.model.candidate;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPLICATION_ACCEPTED;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPLICATION_PENDING;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPLICATION_REJECTED;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -11,6 +15,17 @@ public class ApplicationStatusTest {
     @Test
     public void constructor_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new ApplicationStatus(null));
+    }
+
+    @Test
+    public void constructor_test_success() {
+        ApplicationStatus pending = new ApplicationStatus(VALID_APPLICATION_PENDING);
+        ApplicationStatus accepted = new ApplicationStatus(VALID_APPLICATION_ACCEPTED);
+        ApplicationStatus rejected = new ApplicationStatus(VALID_APPLICATION_REJECTED);
+
+        assertEquals(new ApplicationStatus(VALID_APPLICATION_PENDING), pending);
+        assertEquals(new ApplicationStatus(VALID_APPLICATION_REJECTED), rejected);
+        assertEquals(new ApplicationStatus(VALID_APPLICATION_ACCEPTED), accepted);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/candidate/InterviewStatusTest.java
+++ b/src/test/java/seedu/address/model/candidate/InterviewStatusTest.java
@@ -1,7 +1,11 @@
 package seedu.address.model.candidate;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INTERVIEW_COMPLETED;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INTERVIEW_NOT_SCHEDULED;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INTERVIEW_SCHEDULED;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -11,6 +15,17 @@ public class InterviewStatusTest {
     @Test
     public void constructor_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new InterviewStatus(null));
+    }
+
+    @Test
+    public void constructor_test_success() {
+        InterviewStatus notScheduled = new InterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED);
+        InterviewStatus scheduled = new InterviewStatus(VALID_INTERVIEW_SCHEDULED);
+        InterviewStatus completed = new InterviewStatus(VALID_INTERVIEW_COMPLETED);
+
+        assertEquals(new InterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED), notScheduled);
+        assertEquals(new InterviewStatus(VALID_INTERVIEW_SCHEDULED), scheduled);
+        assertEquals(new InterviewStatus(VALID_INTERVIEW_COMPLETED), completed);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -1,13 +1,13 @@
 package seedu.address.testutil;
 
-import static seedu.address.logic.commands.CommandTestUtil.VALID_APPLICATION_STATUS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPLICATION_PENDING;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_AVAILABILITY_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_AVAILABILITY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COURSE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COURSE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_INTERVIEW_STATUS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_INTERVIEW_NOT_SCHEDULED;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
@@ -36,8 +36,8 @@ public class TypicalPersons {
             .withEmail("E0123456@u.nus.edu")
             .withCourse("Business Analytics")
             .withTags("friends")
-            .withApplicationStatus(VALID_APPLICATION_STATUS)
-            .withInterviewStatus(VALID_INTERVIEW_STATUS)
+            .withApplicationStatus(VALID_APPLICATION_PENDING)
+            .withInterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED)
             .withAvailability("1,2,3")
             .build();
     public static final Candidate BENSON = new CandidateBuilder()
@@ -47,8 +47,8 @@ public class TypicalPersons {
             .withEmail("E0234567@u.nus.edu")
             .withCourse("Computer Engineering")
             .withTags("owesMoney", "friends")
-            .withApplicationStatus(VALID_APPLICATION_STATUS)
-            .withInterviewStatus(VALID_INTERVIEW_STATUS)
+            .withApplicationStatus(VALID_APPLICATION_PENDING)
+            .withInterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED)
             .withAvailability("2,3,4")
             .build();
     public static final Candidate CARL = new CandidateBuilder()
@@ -57,8 +57,8 @@ public class TypicalPersons {
             .withPhone("95352563")
             .withEmail("E0345678@u.nus.edu")
             .withCourse("Computer Science")
-            .withApplicationStatus(VALID_APPLICATION_STATUS)
-            .withInterviewStatus(VALID_INTERVIEW_STATUS)
+            .withApplicationStatus(VALID_APPLICATION_PENDING)
+            .withInterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED)
             .withAvailability("3,4,5")
             .build();
     public static final Candidate DANIEL = new CandidateBuilder()
@@ -68,8 +68,8 @@ public class TypicalPersons {
             .withEmail("E0456789@u.nus.edu")
             .withCourse("Information Security")
             .withTags("friends")
-            .withApplicationStatus(VALID_APPLICATION_STATUS)
-            .withInterviewStatus(VALID_INTERVIEW_STATUS)
+            .withApplicationStatus(VALID_APPLICATION_PENDING)
+            .withInterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED)
             .withAvailability("5,6,7")
             .build();
     public static final Candidate ELLE = new CandidateBuilder()
@@ -78,8 +78,8 @@ public class TypicalPersons {
             .withPhone("94822240")
             .withEmail("E0567890@u.nus.edu")
             .withCourse("Information Systems")
-            .withApplicationStatus(VALID_APPLICATION_STATUS)
-            .withInterviewStatus(VALID_INTERVIEW_STATUS)
+            .withApplicationStatus(VALID_APPLICATION_PENDING)
+            .withInterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED)
             .withAvailability("1,3,5,7")
             .build();
     public static final Candidate FIONA = new CandidateBuilder()
@@ -88,8 +88,8 @@ public class TypicalPersons {
             .withPhone("94824270")
             .withEmail("E0678901@u.nus.edu")
             .withCourse("Business Analytics")
-            .withApplicationStatus(VALID_APPLICATION_STATUS)
-            .withInterviewStatus(VALID_INTERVIEW_STATUS)
+            .withApplicationStatus(VALID_APPLICATION_PENDING)
+            .withInterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED)
             .withAvailability("2,4,6")
             .build();
     public static final Candidate GEORGE = new CandidateBuilder()
@@ -98,8 +98,8 @@ public class TypicalPersons {
             .withPhone("94824420")
             .withEmail("E0789012@u.nus.edu")
             .withCourse("Computer Engineering")
-            .withApplicationStatus(VALID_APPLICATION_STATUS)
-            .withInterviewStatus(VALID_INTERVIEW_STATUS)
+            .withApplicationStatus(VALID_APPLICATION_PENDING)
+            .withInterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED)
             .withAvailability("2,3,4,5,6")
             .build();
 
@@ -110,8 +110,8 @@ public class TypicalPersons {
             .withPhone("84824240")
             .withEmail("E0890123@u.nus.edu")
             .withCourse("Computer Science")
-            .withApplicationStatus(VALID_APPLICATION_STATUS)
-            .withInterviewStatus(VALID_INTERVIEW_STATUS)
+            .withApplicationStatus(VALID_APPLICATION_PENDING)
+            .withInterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED)
             .withAvailability("1,4,7")
             .build();
     public static final Candidate IDA = new CandidateBuilder()
@@ -120,8 +120,8 @@ public class TypicalPersons {
             .withPhone("84821310")
             .withEmail("E0901234@u.nus.edu")
             .withCourse("Information Security")
-            .withApplicationStatus(VALID_APPLICATION_STATUS)
-            .withInterviewStatus(VALID_INTERVIEW_STATUS)
+            .withApplicationStatus(VALID_APPLICATION_PENDING)
+            .withInterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED)
             .withAvailability("3,4,5,6,7")
             .build();
 
@@ -133,8 +133,8 @@ public class TypicalPersons {
             .withEmail(VALID_EMAIL_AMY)
             .withCourse(VALID_COURSE_AMY)
             .withTags(VALID_TAG_FRIEND)
-            .withApplicationStatus(VALID_APPLICATION_STATUS)
-            .withInterviewStatus(VALID_INTERVIEW_STATUS)
+            .withApplicationStatus(VALID_APPLICATION_PENDING)
+            .withInterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED)
             .withAvailability(VALID_AVAILABILITY_AMY)
             .build();
     public static final Candidate BOB = new CandidateBuilder()
@@ -144,8 +144,8 @@ public class TypicalPersons {
             .withEmail(VALID_EMAIL_BOB)
             .withCourse(VALID_COURSE_BOB)
             .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
-            .withApplicationStatus(VALID_APPLICATION_STATUS)
-            .withInterviewStatus(VALID_INTERVIEW_STATUS)
+            .withApplicationStatus(VALID_APPLICATION_PENDING)
+            .withInterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED)
             .withAvailability(VALID_AVAILABILITY_BOB)
             .build();
 


### PR DESCRIPTION
Currently `ApplicationStatus` and `InterviewStatus` are changed manually. 
Let's change it so that `ApplicationStatus` when changed to `Accepted` or `Rejected`, it will trigger `InterviewStatus` to be `Completed`. 

closes #108 