### PR TITLE
Issue #89/#153: Update find/sort command for Seniority, Application Status and Interview Status

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -19,13 +19,14 @@ public class FindCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all candidates whose description contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + " The search can be conducted only on a specific field in candidates' description by specifying the"
+            + " The search will be conducted only on a specific field in candidates' description by specifying the"
             + PREFIX_FIELD + " FIELD argument.\n"
             + "Parameters: " + PREFIX_KEYWORD + "KEYWORD [" + PREFIX_KEYWORD + "MORE_KEYWORDS]... "
             + PREFIX_FIELD + "FIELD\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_KEYWORD + "alice " + PREFIX_KEYWORD + "charlie "
             + PREFIX_FIELD + "name\n"
-            + "Allowable fields to be sorted by include course, email, phone, name, studentid.";
+            + "Allowable fields to be searched include: applicationstatus, availability, candidate, course, email, "
+            + "interviewstatus, name, phone, seniority, studentid.";
 
     private final ContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -18,12 +18,13 @@ public class SortCommand extends Command {
     public static final String COMMAND_WORD = "sort";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts all candidates by the field specified "
-            + "and displays them as a list with index numbers.\n"
+            + "in ascending order (A-Z, 0-9) and displays them as a list with index numbers.\n"
             + " The search can be conducted only on a specific field in candidates' description by specifying the"
             + PREFIX_SORTKEY + " SORTKEY argument.\n"
             + "Parameters: " + PREFIX_SORTKEY + "SORTKEY \n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_SORTKEY + "name\n"
-            + "Allowable fields to be sorted by include course, email, phone, name, studentid.";
+            + "Allowable fields to be sorted by include: applicationstatus, availability, course, email, "
+            + "interviewstatus, name, phone, seniority, studentid.";
 
     private final Comparator<Candidate> sortComparator;
     private final String sortKey;

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -11,11 +11,14 @@ import java.util.stream.Stream;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.candidate.predicate.ApplicationStatusContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.CandidateContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.CourseContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.EmailContainsKeywordsPredicate;
+import seedu.address.model.candidate.predicate.InterviewStatusContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.NameContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.PhoneContainsKeywordsPredicate;
+import seedu.address.model.candidate.predicate.SeniorityContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.StudentIdContainsKeywordsPredicate;
 
 /**
@@ -49,17 +52,23 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         switch (fieldString) {
-        case "email":
-            return new FindCommand(new EmailContainsKeywordsPredicate(keywords));
-        case "course":
-            return new FindCommand(new CourseContainsKeywordsPredicate(keywords));
-        case "name":
-            return new FindCommand(new NameContainsKeywordsPredicate(keywords));
+        case "applicationstatus":
+            return new FindCommand(new ApplicationStatusContainsKeywordsPredicate(keywords));
         case "candidate":
         case "":
             return new FindCommand(new CandidateContainsKeywordsPredicate(keywords));
+        case "course":
+            return new FindCommand(new CourseContainsKeywordsPredicate(keywords));
+        case "email":
+            return new FindCommand(new EmailContainsKeywordsPredicate(keywords));
+        case "interviewstatus":
+            return new FindCommand(new InterviewStatusContainsKeywordsPredicate(keywords));
+        case "name":
+            return new FindCommand(new NameContainsKeywordsPredicate(keywords));
         case "phone":
             return new FindCommand(new PhoneContainsKeywordsPredicate(keywords));
+        case "seniority":
+            return new FindCommand(new SeniorityContainsKeywordsPredicate(keywords));
         case "studentid":
             return new FindCommand(new StudentIdContainsKeywordsPredicate(keywords));
         default:

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -34,17 +34,26 @@ public class SortCommandParser implements Parser<SortCommand> {
         Comparator<Candidate> sortComparator;
 
         switch (sortKey) {
+        case "applicationstatus":
+            sortComparator = Comparator.comparing(l -> l.getApplicationStatus().toString().toLowerCase());
+            break;
         case "course":
             sortComparator = Comparator.comparing(l -> l.getCourse().toString().toLowerCase());
             break;
         case "email":
             sortComparator = Comparator.comparing(l -> l.getEmail().toString().toLowerCase());
             break;
+        case "interviewstatus":
+            sortComparator = Comparator.comparing(l -> l.getInterviewStatus().toString().toLowerCase());
+            break;
         case "phone":
             sortComparator = Comparator.comparing(l -> l.getPhone().toString().toLowerCase());
             break;
         case "name":
             sortComparator = Comparator.comparing(l -> l.getName().toString().toLowerCase());
+            break;
+        case "seniority":
+            sortComparator = Comparator.comparing(l -> l.getSeniority().toString().toLowerCase());
             break;
         case "studentid":
             sortComparator = Comparator.comparing(l -> l.getStudentId().toString().toLowerCase());

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -191,7 +191,7 @@ public class ModelManager implements Model {
     @Override
     public void updateSortedCandidateList(Comparator<Candidate> sortComparator) {
         requireNonNull(sortComparator);
-        addressBook.sortCandidates(filteredCandidates, sortComparator);
+        addressBook.sortCandidates(addressBook.getCandidateList(), sortComparator);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/candidate/predicate/ApplicationStatusContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/candidate/predicate/ApplicationStatusContainsKeywordsPredicate.java
@@ -1,0 +1,52 @@
+package seedu.address.model.candidate.predicate;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.model.candidate.Candidate;
+
+/**
+ * Tests that a {@code Candidate}'s {@code ApplicationStatus} matches any of the keywords given.
+ */
+public class ApplicationStatusContainsKeywordsPredicate extends ContainsKeywordsPredicate
+        implements Predicate<Candidate> {
+    private final List<String> keywords;
+
+    /**
+     * Creates a new {@link ApplicationStatusContainsKeywordsPredicate} object with the
+     * {@link ApplicationStatusContainsKeywordsPredicate#keywords} initialised.
+     * @param keywords contain keyword(s) to find in {@code Candidate}'s {@code ApplicationStatus}.
+     */
+    public ApplicationStatusContainsKeywordsPredicate(List<String> keywords) {
+        super(keywords);
+        this.keywords = keywords;
+    }
+
+    /**
+     * Tests if any part of {@code Candidate}'s {@code ApplicationStatus} matches any of the specified
+     * {@link ApplicationStatusContainsKeywordsPredicate#keywords}.
+     * @param candidate object to retrieve the {@code ApplicationStatus}.
+     * @return true if a match is found, and false otherwise.
+     */
+    @Override
+    public boolean test(Candidate candidate) {
+        return keywords.stream().anyMatch(keyword -> StringUtil
+                .containsStringIgnoreCase(candidate.getApplicationStatus().toString(), keyword));
+    }
+
+    /**
+     * Checks if another object are instances of the same class and contains the same
+     * {@link ApplicationStatusContainsKeywordsPredicate#keywords}.
+     * @param other object to compare against.
+     * @return true if both objects are instances of {@link ApplicationStatusContainsKeywordsPredicate} with the same
+     * {@link ApplicationStatusContainsKeywordsPredicate#keywords}.
+     */
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ApplicationStatusContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((ApplicationStatusContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/candidate/predicate/InterviewStatusContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/candidate/predicate/InterviewStatusContainsKeywordsPredicate.java
@@ -1,0 +1,52 @@
+package seedu.address.model.candidate.predicate;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.model.candidate.Candidate;
+
+/**
+ * Tests that a {@code Candidate}'s {@code InterviewStatus} matches any of the keywords given.
+ */
+public class InterviewStatusContainsKeywordsPredicate extends ContainsKeywordsPredicate
+        implements Predicate<Candidate> {
+    private final List<String> keywords;
+
+    /**
+     * Creates a new {@link InterviewStatusContainsKeywordsPredicate} object with the
+     * {@link InterviewStatusContainsKeywordsPredicate#keywords} initialised.
+     * @param keywords contain keyword(s) to find in {@code Candidate}'s {@code InterviewStatus}.
+     */
+    public InterviewStatusContainsKeywordsPredicate(List<String> keywords) {
+        super(keywords);
+        this.keywords = keywords;
+    }
+
+    /**
+     * Tests if any part of {@code Candidate}'s {@code InterviewStatus} matches any of the specified
+     * {@link InterviewStatusContainsKeywordsPredicate#keywords}.
+     * @param candidate object to retrieve the {@code InterviewStatus}.
+     * @return true if a match is found, and false otherwise.
+     */
+    @Override
+    public boolean test(Candidate candidate) {
+        return keywords.stream().anyMatch(keyword -> StringUtil
+                .containsStringIgnoreCase(candidate.getInterviewStatus().toString(), keyword));
+    }
+
+    /**
+     * Checks if another object are instances of the same class and contains the same
+     * {@link InterviewStatusContainsKeywordsPredicate#keywords}.
+     * @param other object to compare against.
+     * @return true if both objects are instances of {@link InterviewStatusContainsKeywordsPredicate} with the same
+     * {@link InterviewStatusContainsKeywordsPredicate#keywords}.
+     */
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof InterviewStatusContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((InterviewStatusContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/candidate/predicate/SeniorityContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/candidate/predicate/SeniorityContainsKeywordsPredicate.java
@@ -1,0 +1,52 @@
+package seedu.address.model.candidate.predicate;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.model.candidate.Candidate;
+
+/**
+ * Tests that a {@code Candidate}'s {@code Seniority} matches any of the keywords given.
+ */
+public class SeniorityContainsKeywordsPredicate extends ContainsKeywordsPredicate
+        implements Predicate<Candidate> {
+    private final List<String> keywords;
+
+    /**
+     * Creates a new {@link SeniorityContainsKeywordsPredicate} object with the
+     * {@link SeniorityContainsKeywordsPredicate#keywords} initialised.
+     * @param keywords contain keyword(s) to find in {@code Candidate}'s {@code Seniority}.
+     */
+    public SeniorityContainsKeywordsPredicate(List<String> keywords) {
+        super(keywords);
+        this.keywords = keywords;
+    }
+
+    /**
+     * Tests if any part of {@code Candidate}'s {@code Seniority} matches any of the specified
+     * {@link SeniorityContainsKeywordsPredicate#keywords}.
+     * @param candidate object to retrieve the {@code Seniority}.
+     * @return true if a match is found, and false otherwise.
+     */
+    @Override
+    public boolean test(Candidate candidate) {
+        return keywords.stream().anyMatch(keyword -> StringUtil
+                .containsStringIgnoreCase(candidate.getSeniority().toString(), keyword));
+    }
+
+    /**
+     * Checks if another object are instances of the same class and contains the same
+     * {@link SeniorityContainsKeywordsPredicate#keywords}.
+     * @param other object to compare against.
+     * @return true if both objects are instances of {@link SeniorityContainsKeywordsPredicate} with the same
+     * {@link SeniorityContainsKeywordsPredicate#keywords}.
+     */
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof SeniorityContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((SeniorityContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedCandidate.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedCandidate.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.candidate.Address;
 import seedu.address.model.candidate.ApplicationStatus;
 import seedu.address.model.candidate.Availability;
 import seedu.address.model.candidate.Candidate;
@@ -135,7 +134,7 @@ class JsonAdaptedCandidate {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Course.class.getSimpleName()));
         }
         if (!Course.isValidCourse(course)) {
-            throw new IllegalValueException(Address.MESSAGE_CONSTRAINTS);
+            throw new IllegalValueException(Course.MESSAGE_CONSTRAINTS);
         }
         final Course modelCourse = new Course(course);
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.model.candidate.ApplicationStatus;
 import seedu.address.model.candidate.predicate.ApplicationStatusContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.CandidateContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.CourseContainsKeywordsPredicate;

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -9,9 +9,12 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.model.candidate.ApplicationStatus;
+import seedu.address.model.candidate.predicate.ApplicationStatusContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.CandidateContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.CourseContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.EmailContainsKeywordsPredicate;
+import seedu.address.model.candidate.predicate.InterviewStatusContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.NameContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.PhoneContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.StudentIdContainsKeywordsPredicate;
@@ -78,6 +81,20 @@ public class FindCommandParserTest {
 
         // multiple whitespaces between keywords
         assertParseSuccess(parser, "    k/E0324 \t \t  k/149  \t  f/studentid \t", expectedFindStudentIdCommand);
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindStatusCommand() {
+        // no leading and trailing whitespaces
+        FindCommand expectedFindInterviewStatusCommand =
+                new FindCommand(new InterviewStatusContainsKeywordsPredicate(Arrays.asList("pending", "reject")));
+        assertParseSuccess(parser, " k/pending k/reject f/interviewstatus", expectedFindInterviewStatusCommand);
+
+        // multiple whitespaces between keywords
+        FindCommand expectedFindApplicationStatusCommand =
+                new FindCommand(new ApplicationStatusContainsKeywordsPredicate(Arrays.asList("pending", "reject")));
+        assertParseSuccess(parser, " k/  pending    k/  reject   f/     applicationstatus",
+                expectedFindApplicationStatusCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -16,6 +16,7 @@ import seedu.address.model.candidate.predicate.EmailContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.InterviewStatusContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.NameContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.PhoneContainsKeywordsPredicate;
+import seedu.address.model.candidate.predicate.SeniorityContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.StudentIdContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
@@ -94,6 +95,14 @@ public class FindCommandParserTest {
                 new FindCommand(new ApplicationStatusContainsKeywordsPredicate(Arrays.asList("pending", "reject")));
         assertParseSuccess(parser, " k/  pending    k/  reject   f/     applicationstatus",
                 expectedFindApplicationStatusCommand);
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindSeniorityCommand() {
+        // no leading and trailing whitespaces
+        FindCommand expectedFindSeniorityCommand =
+                new FindCommand(new SeniorityContainsKeywordsPredicate(Arrays.asList("2", "com1")));
+        assertParseSuccess(parser, " k/2 k/com1 f/seniority", expectedFindSeniorityCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -55,12 +55,22 @@ public class SortCommandParserTest {
         Comparator<Candidate> sortComparatorStudentId = Comparator.comparing(l -> l.getName().toString().toLowerCase());
         Comparator<Candidate> sortComparatorPhone = Comparator.comparing(l -> l.getName().toString().toLowerCase());
         Comparator<Candidate> sortComparatorEmail = Comparator.comparing(l -> l.getName().toString().toLowerCase());
+        Comparator<Candidate> sortComparatorInterviewStatus =
+                Comparator.comparing(l -> l.getInterviewStatus().toString().toLowerCase());
+        Comparator<Candidate> sortComparatorApplicationStatus =
+                Comparator.comparing(l -> l.getApplicationStatus().toString().toLowerCase());
+        Comparator<Candidate> sortComparatorSeniority =
+                Comparator.comparing(l -> l.getSeniority().toString().toLowerCase());
 
         SortCommand expectedCommandName = new SortCommand(sortComparatorName, "name");
         SortCommand expectedCommandCourse = new SortCommand(sortComparatorCourse, "course");
         SortCommand expectedCommandStudentId = new SortCommand(sortComparatorStudentId, "studentid");
         SortCommand expectedCommandPhone = new SortCommand(sortComparatorPhone, "phone");
         SortCommand expectedCommandEmail = new SortCommand(sortComparatorEmail, "email");
+        SortCommand expectedCommandApplicationStatus = new SortCommand(sortComparatorApplicationStatus,
+                "applicationstatus");
+        SortCommand expectedCommandInterviewStatus = new SortCommand(sortComparatorInterviewStatus, "interviewstatus");
+        SortCommand expectedCommandSeniority = new SortCommand(sortComparatorSeniority, "seniority");
 
         assertParseSuccess(parser, SORT_EMPTY + "name", expectedCommandName);
         assertParseSuccess(parser, " " + PREFIX_SORTKEY + "name", expectedCommandName);
@@ -68,6 +78,9 @@ public class SortCommandParserTest {
         assertParseSuccess(parser, SORT_EMPTY + "studentid", expectedCommandStudentId);
         assertParseSuccess(parser, SORT_EMPTY + "phone", expectedCommandPhone);
         assertParseSuccess(parser, SORT_EMPTY + "email", expectedCommandEmail);
+        assertParseSuccess(parser, SORT_EMPTY + "applicationstatus", expectedCommandApplicationStatus);
+        assertParseSuccess(parser, SORT_EMPTY + "interviewstatus", expectedCommandInterviewStatus);
+        assertParseSuccess(parser, SORT_EMPTY + "seniority", expectedCommandSeniority);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/candidate/predicate/ApplicationStatusContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/candidate/predicate/ApplicationStatusContainsKeywordsPredicateTest.java
@@ -1,0 +1,59 @@
+package seedu.address.model.candidate.predicate;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.CandidateBuilder;
+
+public class ApplicationStatusContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        ApplicationStatusContainsKeywordsPredicate firstPredicate =
+                new ApplicationStatusContainsKeywordsPredicate(firstPredicateKeywordList);
+        ApplicationStatusContainsKeywordsPredicate secondPredicate =
+                new ApplicationStatusContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        ApplicationStatusContainsKeywordsPredicate firstPredicateCopy =
+                new ApplicationStatusContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different candidate -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_applicationStatusContainsKeywords_returnsTrue() {
+        // One keyword
+        ApplicationStatusContainsKeywordsPredicate predicate =
+                new ApplicationStatusContainsKeywordsPredicate(Arrays.asList("pend"));
+        assertTrue(predicate.test(new CandidateBuilder().build()));
+    }
+
+    @Test
+    public void test_applicationStatusDoesNotContainKeywords_returnsFalse() {
+        // Non-matching keywords
+        ApplicationStatusContainsKeywordsPredicate predicate =
+                new ApplicationStatusContainsKeywordsPredicate(Arrays.asList("hi"));
+        assertFalse(predicate.test(new CandidateBuilder().build()));
+    }
+}

--- a/src/test/java/seedu/address/model/candidate/predicate/InterviewStatusContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/candidate/predicate/InterviewStatusContainsKeywordsPredicateTest.java
@@ -1,0 +1,59 @@
+package seedu.address.model.candidate.predicate;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.CandidateBuilder;
+
+public class InterviewStatusContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        InterviewStatusContainsKeywordsPredicate firstPredicate =
+                new InterviewStatusContainsKeywordsPredicate(firstPredicateKeywordList);
+        InterviewStatusContainsKeywordsPredicate secondPredicate =
+                new InterviewStatusContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        InterviewStatusContainsKeywordsPredicate firstPredicateCopy =
+                new InterviewStatusContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different candidate -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_interviewStatusContainsKeywords_returnsTrue() {
+        // One keyword
+        InterviewStatusContainsKeywordsPredicate predicate =
+                new InterviewStatusContainsKeywordsPredicate(Arrays.asList("not"));
+        assertTrue(predicate.test(new CandidateBuilder().build()));
+    }
+
+    @Test
+    public void test_interviewStatusDoesNotContainKeywords_returnsFalse() {
+        // Non-matching keywords
+        InterviewStatusContainsKeywordsPredicate predicate =
+                new InterviewStatusContainsKeywordsPredicate(Arrays.asList("hi"));
+        assertFalse(predicate.test(new CandidateBuilder().build()));
+    }
+}

--- a/src/test/java/seedu/address/model/candidate/predicate/SeniorityContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/candidate/predicate/SeniorityContainsKeywordsPredicateTest.java
@@ -1,0 +1,59 @@
+package seedu.address.model.candidate.predicate;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.CandidateBuilder;
+
+public class SeniorityContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        SeniorityContainsKeywordsPredicate firstPredicate =
+                new SeniorityContainsKeywordsPredicate(firstPredicateKeywordList);
+        SeniorityContainsKeywordsPredicate secondPredicate =
+                new SeniorityContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        SeniorityContainsKeywordsPredicate firstPredicateCopy =
+                new SeniorityContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different candidate -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_seniorityContainsKeywords_returnsTrue() {
+        // One keyword
+        SeniorityContainsKeywordsPredicate predicate =
+                new SeniorityContainsKeywordsPredicate(Arrays.asList("2"));
+        assertTrue(predicate.test(new CandidateBuilder().withSeniority("2").build()));
+    }
+
+    @Test
+    public void test_seniorityDoesNotContainKeywords_returnsFalse() {
+        // Non-matching keywords
+        SeniorityContainsKeywordsPredicate predicate =
+                new SeniorityContainsKeywordsPredicate(Arrays.asList("hi"));
+        assertFalse(predicate.test(new CandidateBuilder().withSeniority("2").build()));
+    }
+}


### PR DESCRIPTION
Currently, the sort and find command are only able to function with previous candidate fields.

The user is therefore not able to search across seniority, interview status and application status.

In this PR: Let's add the switch-case statements for the fields above, and also the relevant ContainsKeywordsPredicate classes for the find command.

Note: This commit also fixes the implementation for updateSortedCandidateList() in the ModelManager. Error in the previous implementation results in the original addressbook candidate list being modified.

Closes #89 and Closes #153 