### PR TITLE
Issue #124: Enhance `view` command to view interviews `today`, this `week` or this `month`

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -10,5 +10,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_CANDIDATE_DISPLAYED_INDEX = "The candidate index provided is invalid";
     public static final String MESSAGE_NO_CANDIDATES_IN_SYSTEM = "There are no candidates in the system!";
     public static final String MESSAGE_CANDIDATES_LISTED_OVERVIEW = "%1$d candidates listed!";
+    public static final String MESSAGE_INTERVIEWS_LISTED_OVERVIEW = "%1$d interviews listed!";
 
 }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -10,6 +10,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyInterviewSchedule;
 import seedu.address.model.candidate.Candidate;
+import seedu.address.model.interview.Interview;
 
 /**
  * API of the Logic component
@@ -31,12 +32,14 @@ public interface Logic {
      */
     ReadOnlyAddressBook getAddressBook();
 
+    ReadOnlyInterviewSchedule getInterviewSchedule();
+
     /**
      * Returns the InterviewSchedule.
      *
      * @see seedu.address.model.Model#getAddressBook()
      */
-    ReadOnlyInterviewSchedule getInterviewSchedule();
+    ObservableList<Interview> getFilteredInterviewSchedule();
 
     /** Returns an unmodifiable view of the filtered list of candidates */
     ObservableList<Candidate> getFilteredCandidateList();

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -16,6 +16,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyInterviewSchedule;
 import seedu.address.model.candidate.Candidate;
+import seedu.address.model.interview.Interview;
 import seedu.address.storage.Storage;
 
 /**
@@ -64,6 +65,11 @@ public class LogicManager implements Logic {
     @Override
     public ReadOnlyInterviewSchedule getInterviewSchedule() {
         return model.getInterviewSchedule();
+    }
+
+    @Override
+    public ObservableList<Interview> getFilteredInterviewSchedule() {
+        return model.getFilteredInterviewSchedule();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -14,15 +14,13 @@ public class ViewCommand extends Command {
     public static final String COMMAND_WORD = "view";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": View all scheduled interviews "
-            + " within a specific time period.\n"
+            + " scheduled within a specific time period.\n"
             + "Parameters: TIME_PERIOD\n"
             + "Example: " + COMMAND_WORD + " today\n"
-            + "Allowable time periods include today (i.e. next 24 hours), week (i.e. this week), "
+            + "Allowable time periods include today (i.e. the same day), week (i.e. this week), "
             + "month (i.e. this month)";
 
     public static final String MESSAGE_NO_INTERVIEWS_IN_SYSTEM = "No interviews scheduled yet!";
-
-    public static final String MESSAGE_SUCCESS = "Listed below are your upcoming interviews: \n";
 
     private final WithinTimePeriodPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -2,11 +2,9 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Comparator;
-import java.util.stream.Collectors;
-
+import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.interview.Interview;
+import seedu.address.model.interview.predicate.WithinTimePeriodPredicate;
 
 /**
  * Lists all candidates in the address book to the user.
@@ -14,22 +12,30 @@ import seedu.address.model.interview.Interview;
 public class ViewCommand extends Command {
 
     public static final String COMMAND_WORD = "view";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": View all scheduled interviews "
+            + " within a specific time period.\n"
+            + "Parameters: TIME_PERIOD\n"
+            + "Example: " + COMMAND_WORD + " today\n"
+            + "Allowable time periods include today (i.e. next 24 hours), week (i.e. this week), "
+            + "month (i.e. this month)";
+
     public static final String MESSAGE_NO_INTERVIEWS_IN_SYSTEM = "No interviews scheduled yet!";
 
     public static final String MESSAGE_SUCCESS = "Listed below are your upcoming interviews: \n";
+
+    private final WithinTimePeriodPredicate predicate;
+
+    public ViewCommand(WithinTimePeriodPredicate predicate) {
+        this.predicate = predicate;
+    }
 
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        String message = model.getInterviewSchedule().getInterviewList().size() > 0
-                ? MESSAGE_SUCCESS
-                + model.getInterviewSchedule().getInterviewList()
-                .stream()
-                .sorted(Comparator.comparing(Interview::getInterviewDateTime))
-                .map(Object::toString)
-                .collect(Collectors.joining("\n"))
-                : MESSAGE_NO_INTERVIEWS_IN_SYSTEM;
-        return new CommandResult(message);
+        model.updateFilteredInterviewSchedule(predicate);
+        return new CommandResult(String
+                .format(Messages.MESSAGE_INTERVIEWS_LISTED_OVERVIEW, model.getFilteredInterviewSchedule().size()));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -78,7 +78,7 @@ public class AddressBookParser {
             return new SortCommandParser().parse(arguments);
 
         case ViewCommand.COMMAND_WORD:
-            return new ViewCommand();
+            return new ViewCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.ScheduleCommand.MESSAGE_INVALID_FORMAT_DATETIME;
 import static seedu.address.logic.commands.ScheduleCommand.MESSAGE_INVALID_PAST_DATETIME;
 
@@ -13,6 +14,7 @@ import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.candidate.Address;
 import seedu.address.model.candidate.ApplicationStatus;
@@ -45,6 +47,23 @@ public class ParserUtil {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+    }
+
+    /**
+     * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
+     * trimmed.
+     * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
+     */
+    public static String parseTimePeriod(String timePeriod) throws ParseException {
+        String trimmedTimePeriod = timePeriod.trim();
+        if (trimmedTimePeriod.equalsIgnoreCase("today")
+                && trimmedTimePeriod.equalsIgnoreCase("week")
+                && trimmedTimePeriod.equalsIgnoreCase("month")
+                && trimmedTimePeriod.equalsIgnoreCase("all")
+                && trimmedTimePeriod.equalsIgnoreCase("")) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
+        }
+        return timePeriod;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -55,15 +55,15 @@ public class ParserUtil {
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static String parseTimePeriod(String timePeriod) throws ParseException {
-        String trimmedTimePeriod = timePeriod.trim();
-        if (trimmedTimePeriod.equalsIgnoreCase("today")
-                && trimmedTimePeriod.equalsIgnoreCase("week")
-                && trimmedTimePeriod.equalsIgnoreCase("month")
-                && trimmedTimePeriod.equalsIgnoreCase("all")
-                && trimmedTimePeriod.equalsIgnoreCase("")) {
+        String trimmedTimePeriod = timePeriod.trim().toLowerCase();
+        if (!trimmedTimePeriod.equalsIgnoreCase("today")
+                && !trimmedTimePeriod.equalsIgnoreCase("week")
+                && !trimmedTimePeriod.equalsIgnoreCase("month")
+                && !trimmedTimePeriod.equalsIgnoreCase("all")
+                && !trimmedTimePeriod.equalsIgnoreCase("")) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
         }
-        return timePeriod;
+        return trimmedTimePeriod;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -1,0 +1,49 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.time.LocalDateTime;
+
+import seedu.address.logic.commands.ViewCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.interview.predicate.AllWithinTimePeriodPredicate;
+import seedu.address.model.interview.predicate.ThisMonthWithinTimePeriodPredicate;
+import seedu.address.model.interview.predicate.ThisWeekWithinTimePeriodPredicate;
+import seedu.address.model.interview.predicate.TodayWithinTimePeriodPredicate;
+
+/**
+ * Parses input arguments and creates a new ViewCommand object
+ */
+public class ViewCommandParser implements Parser<ViewCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ViewCommand
+     * and returns a ViewCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ViewCommand parse(String args) throws ParseException {
+        LocalDateTime now = LocalDateTime.now();
+        try {
+            ParserUtil.parseTimePeriod(args);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE), pe);
+        }
+
+        String timePeriod = ParserUtil.parseTimePeriod(args).trim();
+
+        switch (timePeriod) {
+        case "today":
+            return new ViewCommand(new TodayWithinTimePeriodPredicate(now));
+        case "week":
+            return new ViewCommand(new ThisWeekWithinTimePeriodPredicate(now));
+        case "month":
+            return new ViewCommand(new ThisMonthWithinTimePeriodPredicate(now));
+        case "all":
+        case "":
+        default:
+            return new ViewCommand(new AllWithinTimePeriodPredicate(now));
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -3,7 +3,9 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.time.LocalDateTime;
+import java.util.logging.Logger;
 
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.interview.predicate.AllWithinTimePeriodPredicate;
@@ -15,6 +17,8 @@ import seedu.address.model.interview.predicate.TodayWithinTimePeriodPredicate;
  * Parses input arguments and creates a new ViewCommand object
  */
 public class ViewCommandParser implements Parser<ViewCommand> {
+
+    private final Logger logger = LogsCenter.getLogger(ViewCommandParser.class);
 
     /**
      * Parses the given {@code String} of arguments in the context of the ViewCommand
@@ -30,18 +34,22 @@ public class ViewCommandParser implements Parser<ViewCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE), pe);
         }
 
-        String timePeriod = ParserUtil.parseTimePeriod(args).trim();
+        String timePeriod = ParserUtil.parseTimePeriod(args);
 
         switch (timePeriod) {
         case "today":
+            logger.info("Time period parsed - today");
             return new ViewCommand(new TodayWithinTimePeriodPredicate(now));
         case "week":
+            logger.info("Time period parsed - week");
             return new ViewCommand(new ThisWeekWithinTimePeriodPredicate(now));
         case "month":
+            logger.info("Time period parsed - month");
             return new ViewCommand(new ThisMonthWithinTimePeriodPredicate(now));
         case "all":
         case "":
         default:
+            logger.info("Time period parsed - all time");
             return new ViewCommand(new AllWithinTimePeriodPredicate(now));
         }
     }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -53,10 +53,9 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Reorders the contents of the candidate list by comparator on {@code sortKey}.
      * {@code candidates} must not contain duplicate candidates.
      */
-    public void sortCandidates(List<Candidate> candidates, Comparator<Candidate> sortComparator) {
-        requireNonNull(candidates);
+    public void sortCandidates(Comparator<Candidate> sortComparator) {
         requireNonNull(sortComparator);
-        List<Candidate> candidatesCopy = new ArrayList<Candidate>(candidates);
+        List<Candidate> candidatesCopy = new ArrayList<Candidate>(this.getCandidateList());
         candidatesCopy.sort(sortComparator);
         this.candidates.setCandidates(candidatesCopy);
     }

--- a/src/main/java/seedu/address/model/InterviewSchedule.java
+++ b/src/main/java/seedu/address/model/InterviewSchedule.java
@@ -2,6 +2,8 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import javafx.collections.ObservableList;
@@ -31,6 +33,18 @@ public class InterviewSchedule implements ReadOnlyInterviewSchedule {
      */
     public void setInterviews(List<Interview> interviews) {
         this.interviews.setInterviews(interviews);
+    }
+
+    /**
+     * Reorders the contents of the interview list with the earliest upcoming
+     * interview first followed by later interviews.
+     */
+    public void sortInterviews() {
+        List<Interview> interviewsCopy = new ArrayList<Interview>(this.getInterviewList());
+        Comparator<Interview> comparatorDateTime =
+                Comparator.comparing(l -> l.getInterviewDateTime());
+        interviewsCopy.sort(comparatorDateTime);
+        this.setInterviews(interviewsCopy);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -111,6 +111,12 @@ public interface Model {
 
     //void setInterview(Interview target, Interview editedInterview);
 
+    //=========== Interview Schedule Accessors =============================================================
+
+    ObservableList<Interview> getFilteredInterviewSchedule();
+
+    void updateFilteredInterviewSchedule(Predicate<Interview> predicate);
+
     /** Returns an unmodifiable view of the filtered candidate list */
     ObservableList<Candidate> getFilteredCandidateList();
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -26,13 +26,15 @@ public class ModelManager implements Model {
     private final InterviewSchedule interviewSchedule;
     private final UserPrefs userPrefs;
     private final FilteredList<Candidate> filteredCandidates;
+    private final FilteredList<Interview> filteredInterviewSchedule;
+
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
      */
     public ModelManager(ReadOnlyAddressBook addressBook, ReadOnlyInterviewSchedule interviewList,
                         ReadOnlyUserPrefs userPrefs) {
-        requireAllNonNull(addressBook, userPrefs);
+        requireAllNonNull(addressBook, interviewList, userPrefs);
 
         logger.fine("Initializing with address book: " + addressBook + ", InterviewSchedule: " + interviewList
                 + " and user prefs " + userPrefs);
@@ -42,6 +44,7 @@ public class ModelManager implements Model {
 
         this.interviewSchedule = new InterviewSchedule(interviewList);
         filteredCandidates = new FilteredList<>(this.addressBook.getCandidateList());
+        filteredInterviewSchedule = new FilteredList<>(this.interviewSchedule.getInterviewList());
     }
 
     public ModelManager() {
@@ -135,6 +138,7 @@ public class ModelManager implements Model {
     @Override
     public void setInterviewSchedule(ReadOnlyInterviewSchedule interviewList) {
         this.interviewSchedule.resetData(interviewList);
+        interviewSchedule.sortInterviews();
     }
 
     @Override
@@ -162,6 +166,7 @@ public class ModelManager implements Model {
     @Override
     public void addInterview(Interview interview) {
         interviewSchedule.addInterview(interview);
+        interviewSchedule.sortInterviews();
         //updateFilteredCandidateList(PREDICATE_SHOW_ALL_CANDIDATES);
     }
 
@@ -171,6 +176,21 @@ public class ModelManager implements Model {
 
         interviewSchedule.setInterview(target, editedInterview);
     }*/
+
+    //=========== Interview Schedule Accessors =============================================================
+    @Override
+    public ObservableList<Interview> getFilteredInterviewSchedule() {
+        interviewSchedule.sortInterviews();
+        return filteredInterviewSchedule;
+    }
+
+    @Override
+    public void updateFilteredInterviewSchedule(Predicate<Interview> predicate) {
+        requireNonNull(predicate);
+        interviewSchedule.sortInterviews();
+        filteredInterviewSchedule.setPredicate(predicate);
+    }
+
 
     //=========== Filtered/Sort Candidate List Accessors =============================================================
     /**
@@ -191,7 +211,7 @@ public class ModelManager implements Model {
     @Override
     public void updateSortedCandidateList(Comparator<Candidate> sortComparator) {
         requireNonNull(sortComparator);
-        addressBook.sortCandidates(filteredCandidates, sortComparator);
+        addressBook.sortCandidates(sortComparator);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/interview/predicate/AllWithinTimePeriodPredicate.java
+++ b/src/main/java/seedu/address/model/interview/predicate/AllWithinTimePeriodPredicate.java
@@ -1,0 +1,48 @@
+package seedu.address.model.interview.predicate;
+
+import java.time.LocalDateTime;
+import java.util.function.Predicate;
+
+import seedu.address.model.interview.Interview;
+
+/**
+ * Returns true for all interview dates and times.
+ */
+public class AllWithinTimePeriodPredicate extends WithinTimePeriodPredicate implements Predicate<Interview> {
+    private final LocalDateTime endDateTime;
+
+    /**
+     * Creates a new {@link AllWithinTimePeriodPredicate} object with the
+     * {@link AllWithinTimePeriodPredicate#endDateTime} initialised.
+     * @param currentDateTime contains the current date and time at the point this constructor is called.
+     */
+    public AllWithinTimePeriodPredicate(LocalDateTime currentDateTime) {
+        super(currentDateTime);
+        this.endDateTime = currentDateTime;
+    }
+
+    /**
+     * Returns true for all interview dates and times.
+     * @param interview object to retrieve the date and time.
+     * @return true.
+     */
+    @Override
+    public boolean test(Interview interview) {
+        return true;
+    }
+
+    /**
+     * Checks if another object are instances of the same class and contains the same
+     * {@link AllWithinTimePeriodPredicate#endDateTime}.
+     * @param other object to compare against.
+     * @return true if both objects are instances of {@link AllWithinTimePeriodPredicate} with the same
+     * {@link AllWithinTimePeriodPredicate#endDateTime}.
+     */
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AllWithinTimePeriodPredicate // instanceof handles nulls
+                && endDateTime.equals(((AllWithinTimePeriodPredicate) other).endDateTime)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/interview/predicate/ThisMonthWithinTimePeriodPredicate.java
+++ b/src/main/java/seedu/address/model/interview/predicate/ThisMonthWithinTimePeriodPredicate.java
@@ -1,0 +1,48 @@
+package seedu.address.model.interview.predicate;
+
+import java.time.LocalDateTime;
+import java.util.function.Predicate;
+
+import seedu.address.model.interview.Interview;
+
+/**
+ * Tests that a {@code Interview}'s date and time is within the next month.
+ */
+public class ThisMonthWithinTimePeriodPredicate extends WithinTimePeriodPredicate implements Predicate<Interview> {
+    private final LocalDateTime endDateTime;
+
+    /**
+     * Creates a new {@link ThisMonthWithinTimePeriodPredicate} object with the
+     * {@link ThisMonthWithinTimePeriodPredicate#endDateTime} initialised.
+     * @param currentDateTime contains the current date and time at the point this constructor is called.
+     */
+    public ThisMonthWithinTimePeriodPredicate(LocalDateTime currentDateTime) {
+        super(currentDateTime.plusMonths(1));
+        this.endDateTime = currentDateTime.plusMonths(1);
+    }
+
+    /**
+     * Tests if {@code Interview}'s date and time is within the next month.
+     * @param interview object to retrieve the date and time.
+     * @return true if within 1 month of the current date and time.
+     */
+    @Override
+    public boolean test(Interview interview) {
+        return interview.getInterviewEndDateTime().isBefore(endDateTime);
+    }
+
+    /**
+     * Checks if another object are instances of the same class and contains the same
+     * {@link ThisMonthWithinTimePeriodPredicate#endDateTime}.
+     * @param other object to compare against.
+     * @return true if both objects are instances of {@link ThisMonthWithinTimePeriodPredicate} with the same
+     * {@link ThisMonthWithinTimePeriodPredicate#endDateTime}.
+     */
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ThisMonthWithinTimePeriodPredicate // instanceof handles nulls
+                && endDateTime.equals(((ThisMonthWithinTimePeriodPredicate) other).endDateTime)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/interview/predicate/ThisMonthWithinTimePeriodPredicate.java
+++ b/src/main/java/seedu/address/model/interview/predicate/ThisMonthWithinTimePeriodPredicate.java
@@ -10,6 +10,7 @@ import seedu.address.model.interview.Interview;
  */
 public class ThisMonthWithinTimePeriodPredicate extends WithinTimePeriodPredicate implements Predicate<Interview> {
     private final LocalDateTime endDateTime;
+    private final LocalDateTime currentDateTime;
 
     /**
      * Creates a new {@link ThisMonthWithinTimePeriodPredicate} object with the
@@ -19,6 +20,7 @@ public class ThisMonthWithinTimePeriodPredicate extends WithinTimePeriodPredicat
     public ThisMonthWithinTimePeriodPredicate(LocalDateTime currentDateTime) {
         super(currentDateTime.plusMonths(1));
         this.endDateTime = currentDateTime.plusMonths(1);
+        this.currentDateTime = currentDateTime;
     }
 
     /**
@@ -28,7 +30,8 @@ public class ThisMonthWithinTimePeriodPredicate extends WithinTimePeriodPredicat
      */
     @Override
     public boolean test(Interview interview) {
-        return interview.getInterviewEndDateTime().isBefore(endDateTime);
+        return interview.getInterviewDateTime().isBefore(endDateTime)
+                && interview.getInterviewDateTime().isAfter(currentDateTime);
     }
 
     /**

--- a/src/main/java/seedu/address/model/interview/predicate/ThisWeekWithinTimePeriodPredicate.java
+++ b/src/main/java/seedu/address/model/interview/predicate/ThisWeekWithinTimePeriodPredicate.java
@@ -10,6 +10,7 @@ import seedu.address.model.interview.Interview;
  */
 public class ThisWeekWithinTimePeriodPredicate extends WithinTimePeriodPredicate implements Predicate<Interview> {
     private final LocalDateTime endDateTime;
+    private final LocalDateTime currentDateTime;
 
     /**
      * Creates a new {@link ThisWeekWithinTimePeriodPredicate} object with the
@@ -19,6 +20,7 @@ public class ThisWeekWithinTimePeriodPredicate extends WithinTimePeriodPredicate
     public ThisWeekWithinTimePeriodPredicate(LocalDateTime currentDateTime) {
         super(currentDateTime.plusDays(7));
         this.endDateTime = currentDateTime.plusDays(7);
+        this.currentDateTime = currentDateTime;
     }
 
     /**
@@ -28,7 +30,8 @@ public class ThisWeekWithinTimePeriodPredicate extends WithinTimePeriodPredicate
      */
     @Override
     public boolean test(Interview interview) {
-        return interview.getInterviewEndDateTime().isBefore(endDateTime);
+        return interview.getInterviewDateTime().isBefore(endDateTime)
+                && interview.getInterviewDateTime().isAfter(currentDateTime);
     }
 
     /**

--- a/src/main/java/seedu/address/model/interview/predicate/ThisWeekWithinTimePeriodPredicate.java
+++ b/src/main/java/seedu/address/model/interview/predicate/ThisWeekWithinTimePeriodPredicate.java
@@ -1,0 +1,48 @@
+package seedu.address.model.interview.predicate;
+
+import java.time.LocalDateTime;
+import java.util.function.Predicate;
+
+import seedu.address.model.interview.Interview;
+
+/**
+ * Tests that a {@code Interview}'s date and time is within the next 7 days.
+ */
+public class ThisWeekWithinTimePeriodPredicate extends WithinTimePeriodPredicate implements Predicate<Interview> {
+    private final LocalDateTime endDateTime;
+
+    /**
+     * Creates a new {@link ThisWeekWithinTimePeriodPredicate} object with the
+     * {@link ThisWeekWithinTimePeriodPredicate#endDateTime} initialised.
+     * @param currentDateTime contains the current date and time at the point this constructor is called.
+     */
+    public ThisWeekWithinTimePeriodPredicate(LocalDateTime currentDateTime) {
+        super(currentDateTime.plusDays(7));
+        this.endDateTime = currentDateTime.plusDays(7);
+    }
+
+    /**
+     * Tests if {@code Interview}'s date and time is within the next 7 days.
+     * @param interview object to retrieve the date and time.
+     * @return true if within 7 days of the current date and time.
+     */
+    @Override
+    public boolean test(Interview interview) {
+        return interview.getInterviewEndDateTime().isBefore(endDateTime);
+    }
+
+    /**
+     * Checks if another object are instances of the same class and contains the same
+     * {@link ThisWeekWithinTimePeriodPredicate#endDateTime}.
+     * @param other object to compare against.
+     * @return true if both objects are instances of {@link ThisWeekWithinTimePeriodPredicate} with the same
+     * {@link ThisWeekWithinTimePeriodPredicate#endDateTime}.
+     */
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ThisWeekWithinTimePeriodPredicate // instanceof handles nulls
+                && endDateTime.equals(((ThisWeekWithinTimePeriodPredicate) other).endDateTime)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/interview/predicate/TodayWithinTimePeriodPredicate.java
+++ b/src/main/java/seedu/address/model/interview/predicate/TodayWithinTimePeriodPredicate.java
@@ -1,0 +1,48 @@
+package seedu.address.model.interview.predicate;
+
+import java.time.LocalDateTime;
+import java.util.function.Predicate;
+
+import seedu.address.model.interview.Interview;
+
+/**
+ * Tests that a {@code Interview}'s date and time is within the next 24 hours.
+ */
+public class TodayWithinTimePeriodPredicate extends WithinTimePeriodPredicate implements Predicate<Interview> {
+    private final LocalDateTime endDateTime;
+
+    /**
+     * Creates a new {@link TodayWithinTimePeriodPredicate} object with the
+     * {@link TodayWithinTimePeriodPredicate#endDateTime} initialised.
+     * @param currentDateTime contains the current date and time at the point this constructor is called.
+     */
+    public TodayWithinTimePeriodPredicate(LocalDateTime currentDateTime) {
+        super(currentDateTime.plusHours(24));
+        this.endDateTime = currentDateTime.plusHours(24);
+    }
+
+    /**
+     * Tests if {@code Interview}'s date and time is within the next 24 hours.
+     * @param interview object to retrieve the date and time.
+     * @return true if within 24 hours of the current date and time.
+     */
+    @Override
+    public boolean test(Interview interview) {
+        return interview.getInterviewEndDateTime().isBefore(endDateTime);
+    }
+
+    /**
+     * Checks if another object are instances of the same class and contains the same
+     * {@link TodayWithinTimePeriodPredicate#endDateTime}.
+     * @param other object to compare against.
+     * @return true if both objects are instances of {@link TodayWithinTimePeriodPredicate} with the same
+     * {@link TodayWithinTimePeriodPredicate#endDateTime}.
+     */
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TodayWithinTimePeriodPredicate // instanceof handles nulls
+                && endDateTime.equals(((TodayWithinTimePeriodPredicate) other).endDateTime)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/interview/predicate/TodayWithinTimePeriodPredicate.java
+++ b/src/main/java/seedu/address/model/interview/predicate/TodayWithinTimePeriodPredicate.java
@@ -6,7 +6,7 @@ import java.util.function.Predicate;
 import seedu.address.model.interview.Interview;
 
 /**
- * Tests that a {@code Interview}'s date and time is within the next 24 hours.
+ * Tests that a {@code Interview}'s date and time is within the same day.
  */
 public class TodayWithinTimePeriodPredicate extends WithinTimePeriodPredicate implements Predicate<Interview> {
     private final LocalDateTime endDateTime;
@@ -17,18 +17,18 @@ public class TodayWithinTimePeriodPredicate extends WithinTimePeriodPredicate im
      * @param currentDateTime contains the current date and time at the point this constructor is called.
      */
     public TodayWithinTimePeriodPredicate(LocalDateTime currentDateTime) {
-        super(currentDateTime.plusHours(24));
-        this.endDateTime = currentDateTime.plusHours(24);
+        super(currentDateTime);
+        this.endDateTime = currentDateTime;
     }
 
     /**
-     * Tests if {@code Interview}'s date and time is within the next 24 hours.
+     * Tests if {@code Interview}'s date and time is within the same day.
      * @param interview object to retrieve the date and time.
-     * @return true if within 24 hours of the current date and time.
+     * @return true if within the same day of the current date and time.
      */
     @Override
     public boolean test(Interview interview) {
-        return interview.getInterviewEndDateTime().isBefore(endDateTime);
+        return interview.getInterviewDate().isEqual(endDateTime.toLocalDate());
     }
 
     /**

--- a/src/main/java/seedu/address/model/interview/predicate/WithinTimePeriodPredicate.java
+++ b/src/main/java/seedu/address/model/interview/predicate/WithinTimePeriodPredicate.java
@@ -26,6 +26,4 @@ public abstract class WithinTimePeriodPredicate implements Predicate<Interview> 
                 || (other instanceof WithinTimePeriodPredicate // instanceof handles nulls
                 && endDateTime.equals(((WithinTimePeriodPredicate) other).endDateTime)); // state check
     }
-
-
 }

--- a/src/main/java/seedu/address/model/interview/predicate/WithinTimePeriodPredicate.java
+++ b/src/main/java/seedu/address/model/interview/predicate/WithinTimePeriodPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.interview.predicate;
+
+import java.time.LocalDateTime;
+import java.util.function.Predicate;
+
+import seedu.address.model.interview.Interview;
+
+/**
+ * Represents a predicate of whether the (@code Interview) is within a specific time period.
+ */
+public abstract class WithinTimePeriodPredicate implements Predicate<Interview> {
+    private final LocalDateTime endDateTime;
+
+    public WithinTimePeriodPredicate(LocalDateTime currentDateTime) {
+        this.endDateTime = currentDateTime;
+    }
+
+    @Override
+    public boolean test(Interview interview) {
+        return interview.getInterviewEndDateTime().isBefore(endDateTime);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof WithinTimePeriodPredicate // instanceof handles nulls
+                && endDateTime.equals(((WithinTimePeriodPredicate) other).endDateTime)); // state check
+    }
+
+
+}

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -121,7 +121,7 @@ public class MainWindow extends UiPart<Stage> {
         candidateListPanel = new CandidateListPanel(logic.getFilteredCandidateList());
         candidateListPanelPlaceholder.getChildren().add(candidateListPanel.getRoot());
 
-        interviewListPanel = new InterviewListPanel(logic.getInterviewSchedule().getInterviewList());
+        interviewListPanel = new InterviewListPanel(logic.getFilteredInterviewSchedule());
         interviewListPanelPlaceholder.getChildren().add(interviewListPanel.getRoot());
 
         focusListPanel = new FocusListPanel(logic.getFilteredCandidateList());

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -106,6 +106,11 @@ public class LogicManagerTest {
         assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredCandidateList().remove(0));
     }
 
+    @Test
+    public void getFilteredInterviewSchedule_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredInterviewSchedule().remove(0));
+    }
+
     /**
      * Executes the command and confirms that
      * - no exceptions are thrown <br>

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -153,6 +153,16 @@ public class AddCommandTest {
         }
 
         @Override
+        public ObservableList<Interview> getFilteredInterviewSchedule() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredInterviewSchedule(Predicate<Interview> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasCandidate(Candidate candidate) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -117,6 +117,17 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_view() throws Exception {
         assertTrue(parser.parseCommand(ViewCommand.COMMAND_WORD) instanceof ViewCommand);
+        assertTrue(parser.parseCommand(ViewCommand.COMMAND_WORD + " today  ") instanceof ViewCommand);
+        assertTrue(parser.parseCommand(ViewCommand.COMMAND_WORD + " WEEK  ") instanceof ViewCommand);
+        assertTrue(parser.parseCommand(ViewCommand.COMMAND_WORD + " month  ") instanceof ViewCommand);
+        assertTrue(parser.parseCommand(ViewCommand.COMMAND_WORD + "       \t ") instanceof ViewCommand);
+        assertTrue(parser.parseCommand(ViewCommand.COMMAND_WORD + " all  ") instanceof ViewCommand);
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE), (
+                        ) -> parser.parseCommand(ViewCommand.COMMAND_WORD + " month today  "));
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE), (
+                        ) -> parser.parseCommand(ViewCommand.COMMAND_WORD + " months  "));
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE), (
+                        ) -> parser.parseCommand(ViewCommand.COMMAND_WORD + " this week  "));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -32,6 +32,7 @@ public class ParserUtilTest {
     private static final String INVALID_TAG = "#friend";
     private static final String INVALID_DATE_TIME = "01/01/2000 12:00";
     private static final String INVALID_FORMAT_DATE_TIME = "2025/03/01 10PM";
+    private static final String INVALID_TIME_PERIOD = "A0123456";
 
     private static final String VALID_STUDENT_ID = "E0123456";
     private static final String VALID_NAME = "Rachel Walker";
@@ -41,6 +42,7 @@ public class ParserUtilTest {
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
     private static final String VALID_DATE_TIME = "20/03/2025 10:00";
+    private static final String VALID_TIME_PERIOD = "TODAY";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -65,8 +67,30 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseTimePeriod_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseTimePeriod((String) null));
+    }
+
+    @Test
+    public void parseTimePeriod_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTimePeriod(INVALID_TIME_PERIOD));
+    }
+
+    @Test
+    public void parseTimePeriod_validValueWithoutWhitespace_returnsString() throws Exception {
+        String expectedTimePeriod = "today";
+        assertEquals(expectedTimePeriod, ParserUtil.parseTimePeriod(VALID_TIME_PERIOD));
+    }
+
+    @Test
+    public void parseTimePeriod_validValueWithWhitespace_returnsTrimmedString() throws Exception {
+        String expectedTimePeriod = "today";
+        assertEquals(expectedTimePeriod, ParserUtil.parseTimePeriod(VALID_TIME_PERIOD + WHITESPACE));
+    }
+
+    @Test
     public void parseId_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseName((String) null));
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseStudentId((String) null));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SORTKEY;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class ViewCommandParserTest {
+
+    private ViewCommandParser parser = new ViewCommandParser();
+
+    @Test
+    public void parse_emptyArg_returnsViewCommand() throws ParseException {
+        assert (new ViewCommandParser().parse("     ")) != null;
+    }
+
+    @Test
+    public void parse_validArgs_returnsViewCommand() throws ParseException {
+        assert (new ViewCommandParser().parse("   \t  ")) != null;
+        assert (new ViewCommandParser().parse("   all  ")) != null;
+        assert(new ViewCommandParser().parse("")) != null;
+        assert(new ViewCommandParser().parse("   today   ") != null);
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() throws ParseException {
+        // invalid args
+        assertThrows(ParseException.class, () -> new ViewCommandParser().parse(PREFIX_SORTKEY + "   today   "));
+        assertThrows(ParseException.class, () -> new ViewCommandParser().parse("   today  Week "));
+    }
+}

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -69,7 +69,7 @@ public class AddressBookTest {
         Comparator<Candidate> sortComparator = Comparator.comparing(l -> l.getName().toString().toLowerCase());
         candidatesCopy.sort(sortComparator);
         addressBook.setCandidates(newData);
-        addressBook.sortCandidates(newData, sortComparator);
+        addressBook.sortCandidates(sortComparator);
 
         assertEquals(candidatesCopy, addressBook.getCandidateList());
     }

--- a/src/test/java/seedu/address/model/InterviewScheduleTest.java
+++ b/src/test/java/seedu/address/model/InterviewScheduleTest.java
@@ -66,10 +66,18 @@ public class InterviewScheduleTest {
                         .build();
         List<Interview> newInterviews = Arrays.asList(INTERVIEW_AMY_TYPICAL, editedAliceInterview);
         InterviewScheduleStub newData = new InterviewScheduleStub(newInterviews);
-
         assertThrows(ConflictingInterviewException.class, () -> interviewSchedule.resetData(newData));
     }
 
+    @Test
+    public void setInterviews_withDuplicateInterviewCandidates_throwsDuplicateCandidateException() {
+        // Two interviews with the same candidate
+        Interview editedAliceInterview =
+                new InterviewBuilder(INTERVIEW_ALICE).withInterviewDateTime(TYPICAL_INTERVIEW_DATE_TIME)
+                        .build();
+        List<Interview> newInterviews = Arrays.asList(INTERVIEW_ALICE, editedAliceInterview);
+        assertThrows(DuplicateCandidateException.class, () -> new InterviewSchedule().setInterviews(newInterviews));
+    }
 
     @Test
     public void hasCandidate_nullInterview_throwsNullPointerException() {

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -12,12 +12,16 @@ import static seedu.address.testutil.TypicalInterviews.INTERVIEW_BENSON;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
+import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.candidate.predicate.NameContainsKeywordsPredicate;
+import seedu.address.model.interview.Interview;
+import seedu.address.model.interview.predicate.AllWithinTimePeriodPredicate;
 import seedu.address.testutil.AddressBookBuilder;
 import seedu.address.testutil.InterviewScheduleBuilder;
 
@@ -140,6 +144,22 @@ public class ModelManagerTest {
     public void hasConflictingInterview_interviewInInterviewSchedule_returnsTrue() {
         modelManager.addInterview(INTERVIEW_ALICE);
         assertTrue(modelManager.hasConflictingInterview(INTERVIEW_ALICE));
+    }
+
+    @Test
+    public void getFilteredInterviewSchedule_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredInterviewSchedule().remove(0));
+    }
+
+    @Test
+    public void getFilteredInterviewSchedule_alwaysSorted_returnsEqual() {
+        AllWithinTimePeriodPredicate predicate = new AllWithinTimePeriodPredicate(LocalDateTime.now());
+        modelManager.addInterview(INTERVIEW_BENSON);
+        modelManager.addInterview(INTERVIEW_ALICE);
+        ObservableList<Interview> notSorted = modelManager.getFilteredInterviewSchedule();
+        modelManager.updateFilteredInterviewSchedule(predicate);
+        ObservableList<Interview> sorted = modelManager.getFilteredInterviewSchedule();
+        assertEquals(notSorted, sorted);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -160,6 +160,7 @@ public class ModelManagerTest {
         modelManager.updateFilteredInterviewSchedule(predicate);
         ObservableList<Interview> sorted = modelManager.getFilteredInterviewSchedule();
         assertEquals(notSorted, sorted);
+    }
 
     @Test
     public void deleteInterviewSuccess() {

--- a/src/test/java/seedu/address/model/interview/predicate/AllWithinTimePeriodPredicateTest.java
+++ b/src/test/java/seedu/address/model/interview/predicate/AllWithinTimePeriodPredicateTest.java
@@ -1,0 +1,68 @@
+package seedu.address.model.interview.predicate;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalCandidates.ALICE;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.interview.Interview;
+
+public class AllWithinTimePeriodPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateString = "26/03/2022 14:40";
+        String secondPredicateString = "27/03/2022 14:40";
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+        LocalDateTime firstPredicateDateTime = LocalDateTime.parse(firstPredicateString, formatter);
+        LocalDateTime secondPredicateDateTime = LocalDateTime.parse(secondPredicateString, formatter);
+
+        AllWithinTimePeriodPredicate firstPredicate =
+                new AllWithinTimePeriodPredicate(firstPredicateDateTime);
+        AllWithinTimePeriodPredicate secondPredicate =
+                new AllWithinTimePeriodPredicate(secondPredicateDateTime);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        AllWithinTimePeriodPredicate firstPredicateCopy =
+                new AllWithinTimePeriodPredicate(firstPredicateDateTime);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different candidate -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_interviewAllWithinTimePeriod_returnsTrue() {
+        String firstPredicateString = "31/01/2022 14:40";
+        String secondPredicateString = "28/02/2062 14:39";
+        String thirdPredicateString = "31/12/2022 14:39";
+        String fourthPredicateString = "01/01/2063 14:38";
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+        LocalDateTime firstPredicateDateTime = LocalDateTime.parse(firstPredicateString, formatter);
+        LocalDateTime secondPredicateDateTime = LocalDateTime.parse(secondPredicateString, formatter);
+        LocalDateTime thirdPredicateDateTime = LocalDateTime.parse(thirdPredicateString, formatter);
+        LocalDateTime fourthPredicateDateTime = LocalDateTime.parse(fourthPredicateString, formatter);
+
+        AllWithinTimePeriodPredicate predicateOne =
+                new AllWithinTimePeriodPredicate(firstPredicateDateTime);
+        assertTrue(predicateOne.test(new Interview(ALICE, secondPredicateDateTime)));
+
+        AllWithinTimePeriodPredicate predicateTwo =
+                new AllWithinTimePeriodPredicate(thirdPredicateDateTime);
+        assertTrue(predicateTwo.test(new Interview(ALICE, fourthPredicateDateTime)));
+    }
+}

--- a/src/test/java/seedu/address/model/interview/predicate/ThisMonthWithinTimePeriodPredicateTest.java
+++ b/src/test/java/seedu/address/model/interview/predicate/ThisMonthWithinTimePeriodPredicateTest.java
@@ -1,0 +1,92 @@
+package seedu.address.model.interview.predicate;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalCandidates.ALICE;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.interview.Interview;
+
+public class ThisMonthWithinTimePeriodPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateString = "26/03/2022 14:40";
+        String secondPredicateString = "27/03/2022 14:40";
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+        LocalDateTime firstPredicateDateTime = LocalDateTime.parse(firstPredicateString, formatter);
+        LocalDateTime secondPredicateDateTime = LocalDateTime.parse(secondPredicateString, formatter);
+
+        ThisMonthWithinTimePeriodPredicate firstPredicate =
+                new ThisMonthWithinTimePeriodPredicate(firstPredicateDateTime);
+        ThisMonthWithinTimePeriodPredicate secondPredicate =
+                new ThisMonthWithinTimePeriodPredicate(secondPredicateDateTime);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        ThisMonthWithinTimePeriodPredicate firstPredicateCopy =
+                new ThisMonthWithinTimePeriodPredicate(firstPredicateDateTime);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different candidate -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_interviewMonthWithinTimePeriod_returnsTrue() {
+        String firstPredicateString = "31/01/2022 14:40";
+        String secondPredicateString = "28/02/2022 14:39";
+        String thirdPredicateString = "31/12/2022 14:39";
+        String fourthPredicateString = "01/01/2023 14:38";
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+        LocalDateTime firstPredicateDateTime = LocalDateTime.parse(firstPredicateString, formatter);
+        LocalDateTime secondPredicateDateTime = LocalDateTime.parse(secondPredicateString, formatter);
+        LocalDateTime thirdPredicateDateTime = LocalDateTime.parse(thirdPredicateString, formatter);
+        LocalDateTime fourthPredicateDateTime = LocalDateTime.parse(fourthPredicateString, formatter);
+
+        ThisMonthWithinTimePeriodPredicate predicateOne =
+                new ThisMonthWithinTimePeriodPredicate(firstPredicateDateTime);
+        assertTrue(predicateOne.test(new Interview(ALICE, secondPredicateDateTime)));
+
+        ThisMonthWithinTimePeriodPredicate predicateTwo =
+                new ThisMonthWithinTimePeriodPredicate(thirdPredicateDateTime);
+        assertTrue(predicateTwo.test(new Interview(ALICE, fourthPredicateDateTime)));
+    }
+
+
+    @Test
+    public void test_interviewMonthWithinTimePeriod_returnsFalse() {
+        String firstPredicateString = "31/01/2022 14:40";
+        String secondPredicateString = "01/03/2022 14:40";
+        String thirdPredicateString = "31/12/2022 14:39";
+        String fourthPredicateString = "30/11/2022 14:41";
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+        LocalDateTime firstPredicateDateTime = LocalDateTime.parse(firstPredicateString, formatter);
+        LocalDateTime secondPredicateDateTime = LocalDateTime.parse(secondPredicateString, formatter);
+        LocalDateTime thirdPredicateDateTime = LocalDateTime.parse(thirdPredicateString, formatter);
+        LocalDateTime fourthPredicateDateTime = LocalDateTime.parse(fourthPredicateString, formatter);
+
+        ThisMonthWithinTimePeriodPredicate predicateOne =
+                new ThisMonthWithinTimePeriodPredicate(firstPredicateDateTime);
+        assertFalse(predicateOne.test(new Interview(ALICE, secondPredicateDateTime)));
+
+        ThisMonthWithinTimePeriodPredicate predicateTwo =
+                new ThisMonthWithinTimePeriodPredicate(thirdPredicateDateTime);
+        assertFalse(predicateTwo.test(new Interview(ALICE, fourthPredicateDateTime)));
+    }
+
+}

--- a/src/test/java/seedu/address/model/interview/predicate/ThisWeekWithinTimePeriodPredicateTest.java
+++ b/src/test/java/seedu/address/model/interview/predicate/ThisWeekWithinTimePeriodPredicateTest.java
@@ -1,0 +1,75 @@
+package seedu.address.model.interview.predicate;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalCandidates.ALICE;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.interview.Interview;
+
+public class ThisWeekWithinTimePeriodPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateString = "26/03/2022 14:40";
+        String secondPredicateString = "27/03/2022 14:40";
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+        LocalDateTime firstPredicateDateTime = LocalDateTime.parse(firstPredicateString, formatter);
+        LocalDateTime secondPredicateDateTime = LocalDateTime.parse(secondPredicateString, formatter);
+
+        ThisWeekWithinTimePeriodPredicate firstPredicate =
+                new ThisWeekWithinTimePeriodPredicate(firstPredicateDateTime);
+        ThisWeekWithinTimePeriodPredicate secondPredicate =
+                new ThisWeekWithinTimePeriodPredicate(secondPredicateDateTime);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        ThisWeekWithinTimePeriodPredicate firstPredicateCopy =
+                new ThisWeekWithinTimePeriodPredicate(firstPredicateDateTime);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different candidate -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_interviewWeekWithinTimePeriod_returnsTrue() {
+        String firstPredicateString = "26/03/2022 14:40";
+        String secondPredicateString = "02/04/2022 14:39";
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+        LocalDateTime firstPredicateDateTime = LocalDateTime.parse(firstPredicateString, formatter);
+        LocalDateTime secondPredicateDateTime = LocalDateTime.parse(secondPredicateString, formatter);
+
+        ThisWeekWithinTimePeriodPredicate predicate = new ThisWeekWithinTimePeriodPredicate(firstPredicateDateTime);
+        assertTrue(predicate.test(new Interview(ALICE, secondPredicateDateTime)));
+    }
+
+
+    @Test
+    public void test_interviewWeekWithinTimePeriod_returnsFalse() {
+        String firstPredicateString = "26/03/2022 14:40";
+        String secondPredicateString = "02/04/2022 14:41";
+        String thirdPredicateString = "26/03/2022 13:41";
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+        LocalDateTime firstPredicateDateTime = LocalDateTime.parse(firstPredicateString, formatter);
+        LocalDateTime secondPredicateDateTime = LocalDateTime.parse(secondPredicateString, formatter);
+        LocalDateTime thirdPredicateDateTime = LocalDateTime.parse(thirdPredicateString, formatter);
+
+        ThisWeekWithinTimePeriodPredicate predicate = new ThisWeekWithinTimePeriodPredicate(firstPredicateDateTime);
+        assertFalse(predicate.test(new Interview(ALICE, secondPredicateDateTime)));
+        assertFalse(predicate.test(new Interview(ALICE, thirdPredicateDateTime)));
+    }
+
+}

--- a/src/test/java/seedu/address/model/interview/predicate/TodayWithinTimePeriodPredicateTest.java
+++ b/src/test/java/seedu/address/model/interview/predicate/TodayWithinTimePeriodPredicateTest.java
@@ -1,0 +1,70 @@
+package seedu.address.model.interview.predicate;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalCandidates.ALICE;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.interview.Interview;
+
+public class TodayWithinTimePeriodPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateString = "26/03/2022 14:40";
+        String secondPredicateString = "27/03/2022 14:40";
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+        LocalDateTime firstPredicateDateTime = LocalDateTime.parse(firstPredicateString, formatter);
+        LocalDateTime secondPredicateDateTime = LocalDateTime.parse(secondPredicateString, formatter);
+
+        TodayWithinTimePeriodPredicate firstPredicate =
+                new TodayWithinTimePeriodPredicate(firstPredicateDateTime);
+        TodayWithinTimePeriodPredicate secondPredicate =
+                new TodayWithinTimePeriodPredicate(secondPredicateDateTime);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        TodayWithinTimePeriodPredicate firstPredicateCopy =
+                new TodayWithinTimePeriodPredicate(firstPredicateDateTime);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different candidate -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_interviewTodayWithinTimePeriod_returnsTrue() {
+        String firstPredicateString = "26/03/2022 14:40";
+        String secondPredicateString = "26/03/2022 23:59";
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+        LocalDateTime firstPredicateDateTime = LocalDateTime.parse(firstPredicateString, formatter);
+        LocalDateTime secondPredicateDateTime = LocalDateTime.parse(secondPredicateString, formatter);
+
+        TodayWithinTimePeriodPredicate predicate = new TodayWithinTimePeriodPredicate(firstPredicateDateTime);
+        assertTrue(predicate.test(new Interview(ALICE, secondPredicateDateTime)));
+    }
+
+    @Test
+    public void test_interviewTodayWithinTimePeriod_returnsFalse() {
+        String firstPredicateString = "26/03/2022 14:40";
+        String secondPredicateString = "25/03/2022 23:59";
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+        LocalDateTime firstPredicateDateTime = LocalDateTime.parse(firstPredicateString, formatter);
+        LocalDateTime secondPredicateDateTime = LocalDateTime.parse(secondPredicateString, formatter);
+
+        TodayWithinTimePeriodPredicate predicate = new TodayWithinTimePeriodPredicate(firstPredicateDateTime);
+        assertFalse(predicate.test(new Interview(ALICE, secondPredicateDateTime)));
+    }
+}


### PR DESCRIPTION
Currently, the view command only allows the user to view all scheduled interviews.

The user is not able to filter the interview schedule by time period.

Let's enhance the `view` command with three time period keywords: 'today', 'week' and 'month', to display scheduled interviews within the time period from when the command is entered. Let's also modify the implementation of InterviewSchedule related methods in the ModelManager so that the interviews will be sorted from the earliest to latest interview slot in the UI panel.

Logic:
* `today` = must be after the current date time, and within the same day
* `week` = must be after the current date time, and within 7 days of current date time
* `month` = must be after the current date time, and within 1 month of current date time
* `all` (or if there is no time period states) = all interviews

**Feel free to comment on the above logic implementation!**

Note: @lzan98 I've modified the implementation of some methods within the ModelManager class relating to the retrieval/accessor for the Interview Schedule to allow for the sorting of the Interviews within the schedule. Appreciate your help to confirm that sequences of commands relating to `schedule` will work alongside the view once it's implemented from your end! :D (e.g. `schedule add`, `view week`, `schedule delete`, `view all` etc.)

Closes #124 and Closes #152