### PR TITLE
Update automatic deletion of past scheduled interviews

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -2,6 +2,7 @@ package seedu.address;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -183,6 +184,7 @@ public class MainApp extends Application {
     @Override
     public void start(Stage primaryStage) {
         logger.info("Starting AddressBook " + MainApp.VERSION);
+        model.deletePastInterviewsForInterviewList(LocalDateTime.now());
         ui.start(primaryStage);
     }
 

--- a/src/main/java/seedu/address/model/InterviewSchedule.java
+++ b/src/main/java/seedu/address/model/InterviewSchedule.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
-
 import java.util.List;
 
 import javafx.collections.ObservableList;

--- a/src/main/java/seedu/address/model/InterviewSchedule.java
+++ b/src/main/java/seedu/address/model/InterviewSchedule.java
@@ -2,6 +2,8 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import javafx.collections.ObservableList;
@@ -73,6 +75,23 @@ public class InterviewSchedule implements ReadOnlyInterviewSchedule {
         interviews.setInterview(target, editedInterview);
     }*/
 
+    /**
+     * Deletes past interviews from the list if the scheduled interview time is 30 minutes ago.
+     * @param localDateTime Current date time.
+     */
+    public void deletePastInterviews(LocalDateTime localDateTime) {
+        localDateTime = localDateTime.minusMinutes(30).withSecond(0).withNano(0);
+
+        List<Interview> list = new ArrayList<>();
+        for (Interview i: getInterviewList()) {
+            if (i.getInterviewDateTime().isBefore(localDateTime)) {
+                list.add(i);
+            }
+        }
+        for (Interview i: list) {
+            removeInterview(i);
+        }
+    }
 
     public void removeInterview(Interview key) {
         interviews.remove(key);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.function.Predicate;
 
@@ -125,4 +126,6 @@ public interface Model {
      * @throws NullPointerException if {@code sortKey} is null.
      */
     void updateSortedCandidateList(Comparator<Candidate> sortComparator);
+
+    void deletePastInterviewsForInterviewList(LocalDateTime localDateTime);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -172,6 +173,16 @@ public class ModelManager implements Model {
     public void addInterview(Interview interview) {
         interviewSchedule.addInterview(interview);
         //updateFilteredCandidateList(PREDICATE_SHOW_ALL_CANDIDATES);
+    }
+
+    /**
+     * Deletes all past interviews from the list.
+     * @param localDateTime Current date time.
+     */
+    @Override
+    public void deletePastInterviewsForInterviewList(LocalDateTime localDateTime) {
+        requireNonNull(localDateTime);
+        interviewSchedule.deletePastInterviews(localDateTime);
     }
 
     /*@Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -199,6 +200,11 @@ public class AddCommandTest {
 
         @Override
         public void updateSortedCandidateList(Comparator<Candidate> sortKey) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deletePastInterviewsForInterviewList(LocalDateTime localDateTime) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/model/InterviewScheduleTest.java
+++ b/src/test/java/seedu/address/model/InterviewScheduleTest.java
@@ -7,10 +7,13 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalCandidates.BOB;
 import static seedu.address.testutil.TypicalInterviews.INTERVIEW_ALICE;
 import static seedu.address.testutil.TypicalInterviews.INTERVIEW_AMY_TYPICAL;
+import static seedu.address.testutil.TypicalInterviews.INTERVIEW_BENSON;
 import static seedu.address.testutil.TypicalInterviews.INTERVIEW_BOB_TYPICAL;
+import static seedu.address.testutil.TypicalInterviews.INTERVIEW_CARL;
 import static seedu.address.testutil.TypicalInterviews.TYPICAL_INTERVIEW_DATE_TIME;
 import static seedu.address.testutil.TypicalInterviews.getTypicalInterviewSchedule;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -24,6 +27,7 @@ import seedu.address.model.interview.Interview;
 import seedu.address.model.interview.exceptions.ConflictingInterviewException;
 import seedu.address.model.interview.exceptions.DuplicateCandidateException;
 import seedu.address.testutil.InterviewBuilder;
+import seedu.address.testutil.InterviewScheduleBuilder;
 
 public class InterviewScheduleTest {
 
@@ -126,6 +130,42 @@ public class InterviewScheduleTest {
         InterviewSchedule schedule = new InterviewSchedule();
         schedule.addInterview(interviewAlice);
         schedule.removeInterview(interviewAlice);
+
+        assertEquals(schedule, interviewSchedule);
+    }
+
+    @Test
+    public void deletePastInterviews_withPastInterviews() {
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        Interview pastInterview = new InterviewBuilder(INTERVIEW_BENSON)
+                .withInterviewDateTime(currentDateTime).build();
+        InterviewSchedule schedule = new InterviewSchedule();
+        schedule.addInterview(pastInterview);
+        LocalDateTime dateTimeThirtyOneMinutesIntoFuture = currentDateTime.plusMinutes(31);
+        schedule.deletePastInterviews(dateTimeThirtyOneMinutesIntoFuture);
+
+        assertEquals(schedule, interviewSchedule);
+    }
+
+    @Test
+    public void deletePastInterviews_withNoPastInterviews() {
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        InterviewSchedule schedule = new InterviewScheduleBuilder().withInterview(INTERVIEW_BENSON).build();
+        interviewSchedule.addInterview(INTERVIEW_BENSON);
+        schedule.deletePastInterviews(currentDateTime);
+
+        assertEquals(schedule, interviewSchedule);
+    }
+
+    @Test
+    public void deletePastInterviews_withPastAndFutureInterviews() {
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        Interview pastInterview = new InterviewBuilder(INTERVIEW_CARL).withInterviewDateTime(currentDateTime).build();
+        InterviewSchedule schedule = new InterviewScheduleBuilder()
+                .withInterview(INTERVIEW_BENSON).withInterview(pastInterview).build();
+        interviewSchedule.addInterview(INTERVIEW_BENSON);
+        LocalDateTime dateTimeThirtyOneMinutesIntoFuture = currentDateTime.plusMinutes(31);
+        schedule.deletePastInterviews(dateTimeThirtyOneMinutesIntoFuture);
 
         assertEquals(schedule, interviewSchedule);
     }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -12,12 +12,14 @@ import static seedu.address.testutil.TypicalInterviews.INTERVIEW_BENSON;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.candidate.predicate.NameContainsKeywordsPredicate;
+import seedu.address.model.interview.Interview;
 import seedu.address.testutil.AddressBookBuilder;
 import seedu.address.testutil.InterviewScheduleBuilder;
 
@@ -165,6 +167,58 @@ public class ModelManagerTest {
         modelManager = new ModelManager(addressBook, emptyInterviewSchedule, userPrefs);
         ModelManager modelManagerCopy = new ModelManager(addressBook, emptyInterviewSchedule, userPrefs);
         modelManager.deleteInterviewForCandidate(ALICE);
+
+        assertEquals(modelManager, modelManagerCopy);
+    }
+
+    @Test
+    public void deletePastInterviews_noPastInterviews() {
+        AddressBook addressBook = new AddressBook();
+        InterviewSchedule interviewSchedule = new InterviewScheduleBuilder().withInterview(INTERVIEW_ALICE).build();
+        UserPrefs userPrefs = new UserPrefs();
+
+        modelManager = new ModelManager(addressBook, interviewSchedule, userPrefs);
+        ModelManager modelManagerCopy = new ModelManager(addressBook, interviewSchedule, userPrefs);
+        LocalDateTime localDateTime = LocalDateTime.now();
+        modelManager.deletePastInterviewsForInterviewList(localDateTime);
+
+        assertEquals(modelManager, modelManagerCopy);
+    }
+
+    @Test
+    public void deletePastInterviews_hasPastInterviews() {
+        AddressBook addressBook = new AddressBook();
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        Interview pastInterview = new Interview(ALICE, currentDateTime);
+
+        InterviewSchedule interviewSchedule = new InterviewScheduleBuilder().withInterview(pastInterview).build();
+        InterviewSchedule emptyInterviewSchedule = new InterviewScheduleBuilder().build();
+        UserPrefs userPrefs = new UserPrefs();
+
+        modelManager = new ModelManager(addressBook, interviewSchedule, userPrefs);
+        ModelManager modelManagerCopy = new ModelManager(addressBook, emptyInterviewSchedule, userPrefs);
+        LocalDateTime dateTimeThirtyOneMinutesIntoFuture = currentDateTime.plusMinutes(31);
+        modelManager.deletePastInterviewsForInterviewList(dateTimeThirtyOneMinutesIntoFuture);
+
+        assertEquals(modelManager, modelManagerCopy);
+    }
+
+    @Test
+    public void deletePastInterviews_hasBothPastAndFutureInterviews() {
+        AddressBook addressBook = new AddressBook();
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        Interview pastInterview = new Interview(ALICE, currentDateTime);
+
+        InterviewSchedule interviewSchedule = new InterviewScheduleBuilder()
+                .withInterview(pastInterview).withInterview(INTERVIEW_BENSON).build();
+        InterviewSchedule emptyInterviewSchedule = new InterviewScheduleBuilder()
+                .withInterview(INTERVIEW_BENSON).build();
+        UserPrefs userPrefs = new UserPrefs();
+
+        modelManager = new ModelManager(addressBook, interviewSchedule, userPrefs);
+        ModelManager modelManagerCopy = new ModelManager(addressBook, emptyInterviewSchedule, userPrefs);
+        LocalDateTime dateTimeThirtyOneMinutesIntoFuture = currentDateTime.plusMinutes(31);
+        modelManager.deletePastInterviewsForInterviewList(dateTimeThirtyOneMinutesIntoFuture);
 
         assertEquals(modelManager, modelManagerCopy);
     }


### PR DESCRIPTION
Brief summary of what this feature does:
- Deletes interviews on startup of the application only
- Deletes interviews that are 31 mins ago, since each interview time slot is 30 minutes long


Closes #140