### PR TITLE
Issue #162: `find` based on Candidate's availability

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -19,8 +19,8 @@ public class FindCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all candidates whose description contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + " The search will be conducted only on a specific field in candidates' description by specifying the"
-            + PREFIX_FIELD + " FIELD argument.\n"
+            + "The search will be conducted only on a specific field in candidates' description by specifying the "
+            + PREFIX_FIELD + "FIELD argument.\n"
             + "Parameters: " + PREFIX_KEYWORD + "KEYWORD [" + PREFIX_KEYWORD + "MORE_KEYWORDS]... "
             + PREFIX_FIELD + "FIELD\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_KEYWORD + "alice " + PREFIX_KEYWORD + "charlie "

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -12,6 +12,7 @@ import java.util.stream.Stream;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.candidate.predicate.ApplicationStatusContainsKeywordsPredicate;
+import seedu.address.model.candidate.predicate.AvailabilityContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.CandidateContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.CourseContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.EmailContainsKeywordsPredicate;
@@ -54,6 +55,8 @@ public class FindCommandParser implements Parser<FindCommand> {
         switch (fieldString) {
         case "applicationstatus":
             return new FindCommand(new ApplicationStatusContainsKeywordsPredicate(keywords));
+        case "availability":
+            return new FindCommand(new AvailabilityContainsKeywordsPredicate(keywords));
         case "candidate":
         case "":
             return new FindCommand(new CandidateContainsKeywordsPredicate(keywords));

--- a/src/main/java/seedu/address/model/candidate/predicate/AvailabilityContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/candidate/predicate/AvailabilityContainsKeywordsPredicate.java
@@ -11,7 +11,7 @@ import seedu.address.model.candidate.Candidate;
  * Tests that a {@code Candidate}'s {@code Availability} matches any of the keywords given.
  */
 public class AvailabilityContainsKeywordsPredicate extends ContainsKeywordsPredicate implements Predicate<Candidate> {
-    private static final String[] DAYS_IN_FULL = { "", "MON", "TUE", "WED", "THU", "FRI" };
+    public static final String[] DAYS_IN_FULL = { "", "MON", "TUE", "WED", "THU", "FRI" };
     private final List<String> keywords;
 
     /**

--- a/src/main/java/seedu/address/model/candidate/predicate/AvailabilityContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/candidate/predicate/AvailabilityContainsKeywordsPredicate.java
@@ -1,0 +1,59 @@
+package seedu.address.model.candidate.predicate;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.model.candidate.Candidate;
+
+/**
+ * Tests that a {@code Candidate}'s {@code Availability} matches any of the keywords given.
+ */
+public class AvailabilityContainsKeywordsPredicate extends ContainsKeywordsPredicate implements Predicate<Candidate> {
+    private static final String[] DAYS_IN_FULL = { "", "MON", "TUE", "WED", "THU", "FRI" };
+    private final List<String> keywords;
+
+    /**
+     * Creates a new {@link AvailabilityContainsKeywordsPredicate} object with the
+     * {@link AvailabilityContainsKeywordsPredicate#keywords} initialised.
+     * @param keywords contain keyword(s) to find in {@code Candidate}'s {@code Availability}.
+     */
+    public AvailabilityContainsKeywordsPredicate(List<String> keywords) {
+        super(keywords);
+        this.keywords = keywords;
+    }
+
+    /**
+     * Tests if any part of {@code Candidate}'s {@code Availability} matches any of the specified
+     * {@link AvailabilityContainsKeywordsPredicate#keywords}.
+     * @param candidate object to retrieve the {@code Availability}.
+     * @return true if a match is found, and false otherwise.
+     */
+    @Override
+    public boolean test(Candidate candidate) {
+        String availability = candidate.getAvailability().toString();
+        int[] availArr = Arrays.stream(availability.split(",")).mapToInt((Integer::parseInt)).toArray();
+        HashMap<String, Integer> availMap = new HashMap<>();
+
+        for (Integer i: availArr) {
+            availMap.put(DAYS_IN_FULL[i], i);
+        }
+
+        return keywords.stream().anyMatch(keyword -> availMap.containsKey(keyword.toUpperCase()));
+    }
+
+    /**
+     * Checks if another object are instances of the same class and contains the same
+     * {@link AvailabilityContainsKeywordsPredicate#keywords}.
+     * @param other object to compare against.
+     * @return true if both objects are instances of {@link AvailabilityContainsKeywordsPredicate} with the same
+     * {@link AvailabilityContainsKeywordsPredicate#keywords}.
+     */
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AvailabilityContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((AvailabilityContainsKeywordsPredicate) other).keywords)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/candidate/predicate/CandidateContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/candidate/predicate/CandidateContainsKeywordsPredicate.java
@@ -46,8 +46,6 @@ public class CandidateContainsKeywordsPredicate extends ContainsKeywordsPredicat
             sb.append(AvailabilityContainsKeywordsPredicate.DAYS_IN_FULL[availArr[i]]).append(",");
         }
 
-        System.out.println(sb);
-
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsStringIgnoreCase(sb.toString(), keyword));
     }

--- a/src/main/java/seedu/address/model/candidate/predicate/CandidateContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/candidate/predicate/CandidateContainsKeywordsPredicate.java
@@ -1,5 +1,6 @@
 package seedu.address.model.candidate.predicate;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -30,8 +31,25 @@ public class CandidateContainsKeywordsPredicate extends ContainsKeywordsPredicat
      */
     @Override
     public boolean test(Candidate candidate) {
+        StringBuilder sb = new StringBuilder();
+        String[] separatedCandidate = candidate.toString().split("Availability: ");
+        int[] availArr = Arrays.stream(separatedCandidate[1].split(",")).mapToInt((Integer::parseInt)).toArray();
+
+        sb.append(separatedCandidate[0]).append(" Availability: ");
+
+        for (int i = 0; i < availArr.length; ++i) {
+            if (i + 1 == availArr.length) {
+                sb.append(AvailabilityContainsKeywordsPredicate.DAYS_IN_FULL[availArr[i]]);
+                break;
+            }
+
+            sb.append(AvailabilityContainsKeywordsPredicate.DAYS_IN_FULL[availArr[i]]).append(",");
+        }
+
+        System.out.println(sb);
+
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsStringIgnoreCase(candidate.toString(), keyword));
+                .anyMatch(keyword -> StringUtil.containsStringIgnoreCase(sb.toString(), keyword));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.candidate.predicate.ApplicationStatusContainsKeywordsPredicate;
+import seedu.address.model.candidate.predicate.AvailabilityContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.CandidateContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.CourseContainsKeywordsPredicate;
 import seedu.address.model.candidate.predicate.EmailContainsKeywordsPredicate;
@@ -121,5 +122,21 @@ public class FindCommandParserTest {
 
         // no field specified
         assertParseSuccess(parser, "    k/Amy \t  k/computer science  \t  \t", expectedFindCandidateCommand);
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindAvailabilityCommand() {
+        // no leading and trailing whitespaces
+        FindCommand expectedFindAvailabilityCommand =
+                new FindCommand(new AvailabilityContainsKeywordsPredicate(Arrays.asList("Mon", "Fri")));
+        assertParseSuccess(parser, " k/Mon k/Fri f/availability", expectedFindAvailabilityCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser,
+                "    k/Mon \t  k/Fri  \t  f/availability \t", expectedFindAvailabilityCommand);
+
+        // multiple whitespaces in keywords
+        assertParseSuccess(parser,
+                "    k/  Mon \t  k/     Fri  \t  f/availability \t", expectedFindAvailabilityCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -122,6 +122,11 @@ public class FindCommandParserTest {
 
         // no field specified
         assertParseSuccess(parser, "    k/Amy \t  k/computer science  \t  \t", expectedFindCandidateCommand);
+
+        // no field specified
+        expectedFindCandidateCommand =
+                new FindCommand(new CandidateContainsKeywordsPredicate(Arrays.asList("Mon", "Fri")));
+        assertParseSuccess(parser, "    k/Mon \t  k/Fri  \t  \t", expectedFindCandidateCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/candidate/predicate/AvailabilityContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/candidate/predicate/AvailabilityContainsKeywordsPredicateTest.java
@@ -1,0 +1,70 @@
+package seedu.address.model.candidate.predicate;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.CandidateBuilder;
+
+public class AvailabilityContainsKeywordsPredicateTest {
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("Mon");
+        List<String> secondPredicateKeywordList = Arrays.asList("Mon", "Tue");
+
+        AvailabilityContainsKeywordsPredicate firstPredicate =
+                new AvailabilityContainsKeywordsPredicate(firstPredicateKeywordList);
+        AvailabilityContainsKeywordsPredicate secondPredicate =
+                new AvailabilityContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        AvailabilityContainsKeywordsPredicate firstPredicateCopy =
+                new AvailabilityContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different candidate -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_availabilityContainsKeywords_returnsTrue() {
+        // One keyword - Normal case
+        AvailabilityContainsKeywordsPredicate predicate =
+                new AvailabilityContainsKeywordsPredicate(Arrays.asList("Mon"));
+        assertTrue(predicate.test(new CandidateBuilder().withAvailability("1,2").build()));
+
+        // Multiple keywords - Normal case
+        predicate = new AvailabilityContainsKeywordsPredicate(Arrays.asList("Mon", "Wed", "Fri"));
+        assertTrue(predicate.test(new CandidateBuilder().withAvailability("1,2").build()));
+
+        // One keyword - Odd case
+        predicate = new AvailabilityContainsKeywordsPredicate(Arrays.asList("MOn"));
+        assertTrue(predicate.test(new CandidateBuilder().withAvailability("1,2").build()));
+
+        // Multiple keywords - Odd case
+        predicate = new AvailabilityContainsKeywordsPredicate(Arrays.asList("mOn", "WeD", "FRi"));
+        assertTrue(predicate.test(new CandidateBuilder().withAvailability("1,2").build()));
+    }
+
+    @Test
+    public void test_availabilityDoesNotContainKeywords_returnsFalse() {
+        // Non-matching keywords
+        AvailabilityContainsKeywordsPredicate predicate =
+                new AvailabilityContainsKeywordsPredicate(Arrays.asList("Monday"));
+        assertFalse(predicate.test(new CandidateBuilder().withAvailability("1,2").build()));
+    }
+}

--- a/src/test/java/seedu/address/model/candidate/predicate/CandidateContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/candidate/predicate/CandidateContainsKeywordsPredicateTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.candidate.Candidate;
 import seedu.address.testutil.CandidateBuilder;
 
 public class CandidateContainsKeywordsPredicateTest {
@@ -43,26 +44,39 @@ public class CandidateContainsKeywordsPredicateTest {
 
     @Test
     public void test_candidateContainsKeywords_returnsTrue() {
+        Candidate candidate = new CandidateBuilder().withName("Alice").withPhone("87654321")
+                .withEmail("alice@email.com").withCourse("Business Analytics")
+                .withStudentId("E0324444").withAvailability("1,2,3").build();
+
         // One keyword
-        CandidateContainsKeywordsPredicate predicate = new CandidateContainsKeywordsPredicate(Collections.singletonList(
-                "Alice"));
-        assertTrue(predicate.test(new CandidateBuilder().withName("Alice").withPhone("87654321")
-                .withEmail("alice@email.com").withCourse("Business Analytics").withStudentId("E0324444").build()));
+        CandidateContainsKeywordsPredicate predicate =
+                new CandidateContainsKeywordsPredicate(Collections.singletonList("Alice"));
+        assertTrue(predicate.test(candidate));
 
         // Multiple keywords
         predicate = new CandidateContainsKeywordsPredicate(Arrays.asList("Alice", "Business Analytics"));
-        assertTrue(predicate.test(new CandidateBuilder().withName("Alice").withPhone("87654321")
-                .withEmail("alice@email.com").withCourse("Business Analytics").withStudentId("E0324444").build()));
+        assertTrue(predicate.test(candidate));
 
         // Only one matching keyword
         predicate = new CandidateContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
-        assertTrue(predicate.test(new CandidateBuilder().withName("Alice").withPhone("87654321")
-                .withEmail("alice@email.com").withCourse("Business Analytics").withStudentId("E0324444").build()));
+        assertTrue(predicate.test(candidate));
 
         // Mixed-case keywords
         predicate = new CandidateContainsKeywordsPredicate(Arrays.asList("aLIce", "e0324"));
-        assertTrue(predicate.test(new CandidateBuilder().withName("Alice").withPhone("87654321")
-                .withEmail("alice@email.com").withCourse("Business Analytics").withStudentId("E0324444").build()));
+        assertTrue(predicate.test(candidate));
+
+        // Availability: One keyword
+        predicate = new CandidateContainsKeywordsPredicate(Collections.singletonList(
+                "Mon"));
+        assertTrue(predicate.test(candidate));
+
+        // Availability: Multiple keywords
+        predicate = new CandidateContainsKeywordsPredicate(Arrays.asList("Mon", "Tue", "Wed"));
+        assertTrue(predicate.test(candidate));
+
+        // Mixed-case keywords
+        predicate = new CandidateContainsKeywordsPredicate(Arrays.asList("moN", "TuE", "WED"));
+        assertTrue(predicate.test(candidate));
     }
 
     @Test


### PR DESCRIPTION
This PR consists of the following changes:
- Added additional field `availability` for user to search for when using the `find` command
- Added supporting test cases
- Fix minor bugs

Thanks @charmainehly for creating the issue!

Closes #162.