### PR TITLE
Fix implementation of find command for candidate field

### DIFF
--- a/src/main/java/seedu/address/model/candidate/Seniority.java
+++ b/src/main/java/seedu/address/model/candidate/Seniority.java
@@ -4,7 +4,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents a Candidate's seniority in TAlent Assistant™.
- * Guarantees: immutable; is valid as declared in {@link #isValidSeniority(int)}
+ * Guarantees: immutable; is valid as declared in {@link #isValidSeniority(String)}
  */
 public class Seniority {
     public static final String MESSAGE_CONSTRAINTS =
@@ -31,6 +31,10 @@ public class Seniority {
      */
     public static boolean isValidSeniority(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    public String toSearchString() {
+        return "COM" + seniority;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/candidate/Seniority.java
+++ b/src/main/java/seedu/address/model/candidate/Seniority.java
@@ -34,7 +34,7 @@ public class Seniority {
     }
 
     public String toSearchString() {
-        return "COM" + seniority;
+        return COM_VALUE + seniority;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/candidate/predicate/CandidateContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/candidate/predicate/CandidateContainsKeywordsPredicate.java
@@ -40,12 +40,19 @@ public class CandidateContainsKeywordsPredicate extends ContainsKeywordsPredicat
                 sb.append(AvailabilityContainsKeywordsPredicate.DAYS_IN_FULL[availArr[i]]);
                 break;
             }
-
             sb.append(AvailabilityContainsKeywordsPredicate.DAYS_IN_FULL[availArr[i]]).append(",");
         }
 
-        return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsStringIgnoreCase(sb.toString(), keyword));
+        return keywords.stream().anyMatch(keyword ->
+                StringUtil.containsStringIgnoreCase(candidate.getApplicationStatus().toString(), keyword)
+                        || StringUtil.containsStringIgnoreCase(candidate.getCourse().toString(), keyword)
+                        || StringUtil.containsStringIgnoreCase(candidate.getEmail().toString(), keyword)
+                        || StringUtil.containsStringIgnoreCase(candidate.getInterviewStatus().toString(), keyword)
+                        || StringUtil.containsStringIgnoreCase(candidate.getName().toString(), keyword)
+                        || StringUtil.containsStringIgnoreCase(candidate.getPhone().toString(), keyword)
+                        || StringUtil.containsStringIgnoreCase(candidate.getSeniority().toSearchString(), keyword)
+                        || StringUtil.containsStringIgnoreCase(candidate.getStudentId().toString(), keyword)
+                        || StringUtil.containsStringIgnoreCase(sb.toString(), keyword));
     }
 
     /**

--- a/src/main/java/seedu/address/model/candidate/predicate/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/candidate/predicate/NameContainsKeywordsPredicate.java
@@ -29,7 +29,7 @@ public class NameContainsKeywordsPredicate extends ContainsKeywordsPredicate imp
     @Override
     public boolean test(Candidate candidate) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsStringIgnoreCase(candidate.getName().fullName, keyword));
+                .anyMatch(keyword -> StringUtil.containsStringIgnoreCase(candidate.getName().toString(), keyword));
     }
 
     /**

--- a/src/main/java/seedu/address/model/candidate/predicate/SeniorityContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/candidate/predicate/SeniorityContainsKeywordsPredicate.java
@@ -30,7 +30,7 @@ public class SeniorityContainsKeywordsPredicate extends ContainsKeywordsPredicat
     @Override
     public boolean test(Candidate candidate) {
         return keywords.stream().anyMatch(keyword -> StringUtil
-                .containsStringIgnoreCase(candidate.getSeniority().toString(), keyword));
+                .containsStringIgnoreCase(candidate.getSeniority().toSearchString(), keyword));
     }
 
     /**

--- a/src/test/java/seedu/address/model/candidate/predicate/CandidateContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/candidate/predicate/CandidateContainsKeywordsPredicateTest.java
@@ -78,8 +78,24 @@ public class CandidateContainsKeywordsPredicateTest {
         predicate = new CandidateContainsKeywordsPredicate(Arrays.asList("moN", "TuE", "WED"));
         assertTrue(predicate.test(candidate));
 
-        // Availability: Multiple keywords
+        // Seniority
         predicate = new CandidateContainsKeywordsPredicate(Arrays.asList("com1"));
+        assertTrue(predicate.test(candidate));
+
+        // Phone
+        predicate = new CandidateContainsKeywordsPredicate(Arrays.asList("76543"));
+        assertTrue(predicate.test(candidate));
+
+        // Email
+        predicate = new CandidateContainsKeywordsPredicate(Arrays.asList("alice@email."));
+        assertTrue(predicate.test(candidate));
+
+        // Course
+        predicate = new CandidateContainsKeywordsPredicate(Arrays.asList("business"));
+        assertTrue(predicate.test(candidate));
+
+        // Student ID
+        predicate = new CandidateContainsKeywordsPredicate(Arrays.asList("444"));
         assertTrue(predicate.test(candidate));
     }
 

--- a/src/test/java/seedu/address/model/candidate/predicate/CandidateContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/candidate/predicate/CandidateContainsKeywordsPredicateTest.java
@@ -46,7 +46,7 @@ public class CandidateContainsKeywordsPredicateTest {
     public void test_candidateContainsKeywords_returnsTrue() {
         Candidate candidate = new CandidateBuilder().withName("Alice").withPhone("87654321")
                 .withEmail("alice@email.com").withCourse("Business Analytics")
-                .withStudentId("E0324444").withAvailability("1,2,3").build();
+                .withStudentId("E0324444").withAvailability("1,2,3").withSeniority("1").build();
 
         // One keyword
         CandidateContainsKeywordsPredicate predicate =
@@ -76,6 +76,10 @@ public class CandidateContainsKeywordsPredicateTest {
 
         // Mixed-case keywords
         predicate = new CandidateContainsKeywordsPredicate(Arrays.asList("moN", "TuE", "WED"));
+        assertTrue(predicate.test(candidate));
+
+        // Availability: Multiple keywords
+        predicate = new CandidateContainsKeywordsPredicate(Arrays.asList("com1"));
         assertTrue(predicate.test(candidate));
     }
 


### PR DESCRIPTION
Currently, the find command searches for all fields under each candidate via the candidate.toString() method.

This causes the search to include irrelevant strings e.g."availability" and "phone". This also results in edge cases
where find k/availability f/candidate will bring up positive search results.

Let's fix the implementation in the CandidateContainsKeywordsPredicate class so that the find command will separately check through each of the candidate's fields and return through if any of these fields include any of the keywords.

Note: Small edit to Seniority class and predicate class to enable the find command to search according to the text that
the candidate card in the gui displays, i.e. COM1, COM2 etc.

Closes #189 