### PR TITLE
Issue #178: Polishing the `UI`

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FocusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FocusCommand.java
@@ -15,7 +15,7 @@ import seedu.address.model.candidate.Candidate;
 public class FocusCommand extends Command {
 
     public static final String MESSAGE_FOCUS_CANDIDATE = "Details of candidate shown";
-    public static final String MESSAGE_USAGE = "Focus [INDEX]";
+    public static final String MESSAGE_USAGE = "focus [INDEX]";
     public static final String COMMAND_WORD = "focus";
     private final Index targetIndex;
 

--- a/src/main/java/seedu/address/ui/CandidateCard.java
+++ b/src/main/java/seedu/address/ui/CandidateCard.java
@@ -6,6 +6,15 @@ import static seedu.address.model.candidate.ApplicationStatus.REJECTED_STATUS;
 import static seedu.address.model.candidate.InterviewStatus.COMPLETED;
 import static seedu.address.model.candidate.InterviewStatus.NOT_SCHEDULED;
 import static seedu.address.model.candidate.InterviewStatus.SCHEDULED;
+import static seedu.address.ui.Styles.BLUE;
+import static seedu.address.ui.Styles.BRIGHT_GREEN;
+import static seedu.address.ui.Styles.CHANGE_COLOUR;
+import static seedu.address.ui.Styles.CLOSING_INLINE;
+import static seedu.address.ui.Styles.GREEN;
+import static seedu.address.ui.Styles.GREY;
+import static seedu.address.ui.Styles.RED;
+import static seedu.address.ui.Styles.WHITE_FONT_INLINE;
+import static seedu.address.ui.Styles.YELLOW;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
@@ -28,15 +37,6 @@ public class CandidateCard extends UiPart<Region> {
     // UI Text
     private static final String AVAILABILITY_MSG = "Availability: ";
     private static final String SENIORITY_VALUE = "COM";
-
-    // CSS
-    private static final String RED = "#800000";
-    private static final String GREEN = "#006100";
-    private static final String BLUE = "#0D4BAD";
-    private static final String YELLOW = "#8B8000";
-    private static final String GREY = "#808080";
-    private static final String BRIGHT_GREEN = "#227F0F";
-    private static final String CHANGE_COLOUR = "-fx-background-color: ";
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -139,13 +139,15 @@ public class CandidateCard extends UiPart<Region> {
     public void setAvailableDays(Availability availability) {
         String[] week = Availability.WEEK;
         boolean[] isAvail = availability.getAvailableListAsBoolean();
+        String availStyle = CHANGE_COLOUR + BRIGHT_GREEN + CLOSING_INLINE + WHITE_FONT_INLINE;
+        String notAvailStyle = CHANGE_COLOUR + GREY + CLOSING_INLINE + WHITE_FONT_INLINE;
 
         for (int i = 0; i < week.length; i++) {
             Label label = new Label(week[i]);
             if (isAvail[i]) {
-                label.setStyle(CHANGE_COLOUR + BRIGHT_GREEN);
+                label.setStyle(availStyle);
             } else {
-                label.setStyle(CHANGE_COLOUR + GREY);
+                label.setStyle(notAvailStyle);
             }
             availableDays.getChildren().add(label);
         }

--- a/src/main/java/seedu/address/ui/CandidateCard.java
+++ b/src/main/java/seedu/address/ui/CandidateCard.java
@@ -6,6 +6,7 @@ import static seedu.address.model.candidate.ApplicationStatus.REJECTED_STATUS;
 import static seedu.address.model.candidate.InterviewStatus.COMPLETED;
 import static seedu.address.model.candidate.InterviewStatus.NOT_SCHEDULED;
 import static seedu.address.model.candidate.InterviewStatus.SCHEDULED;
+import static seedu.address.ui.Styles.AVAILABILITY_ID;
 import static seedu.address.ui.Styles.BLUE;
 import static seedu.address.ui.Styles.BRIGHT_GREEN;
 import static seedu.address.ui.Styles.CHANGE_COLOUR;
@@ -144,6 +145,9 @@ public class CandidateCard extends UiPart<Region> {
 
         for (int i = 0; i < week.length; i++) {
             Label label = new Label(week[i]);
+            label.setId(AVAILABILITY_ID);
+            label.setMinWidth(30);
+
             if (isAvail[i]) {
                 label.setStyle(availStyle);
             } else {

--- a/src/main/java/seedu/address/ui/CandidateCard.java
+++ b/src/main/java/seedu/address/ui/CandidateCard.java
@@ -26,17 +26,16 @@ public class CandidateCard extends UiPart<Region> {
     private static final String FXML = "CandidateListCard.fxml";
 
     // UI Text
-    private static final String APPLICATION_STATUS_MSG = "Application Status : ";
-    private static final String INTERVIEW_STATUS_MSG = "Interview Status : ";
     private static final String AVAILABILITY_MSG = "Availability: ";
     private static final String SENIORITY_VALUE = "COM";
 
     // CSS
     private static final String RED = "#800000";
     private static final String GREEN = "#006100";
-    private static final String YELLOW = "#CBA92B";
+    private static final String BLUE = "#0D4BAD";
+    private static final String YELLOW = "#8B8000";
     private static final String GREY = "#808080";
-    private static final String BRIGHT_GREEN = "#4BB11F";
+    private static final String BRIGHT_GREEN = "#227F0F";
     private static final String CHANGE_COLOUR = "-fx-background-color: ";
 
     /**
@@ -132,7 +131,7 @@ public class CandidateCard extends UiPart<Region> {
             interviewLabel.setStyle(CHANGE_COLOUR + GREEN);
             statusPane.getChildren().add(interviewLabel);
         } else if (interviewString.equals(SCHEDULED)) {
-            interviewLabel.setStyle(CHANGE_COLOUR + YELLOW);
+            interviewLabel.setStyle(CHANGE_COLOUR + BLUE);
             statusPane.getChildren().add(interviewLabel);
         }
     }

--- a/src/main/java/seedu/address/ui/FocusCard.java
+++ b/src/main/java/seedu/address/ui/FocusCard.java
@@ -7,6 +7,15 @@ import static seedu.address.model.candidate.ApplicationStatus.REJECTED_STATUS;
 import static seedu.address.model.candidate.InterviewStatus.COMPLETED;
 import static seedu.address.model.candidate.InterviewStatus.NOT_SCHEDULED;
 import static seedu.address.model.candidate.InterviewStatus.SCHEDULED;
+import static seedu.address.ui.Styles.BLUE;
+import static seedu.address.ui.Styles.BRIGHT_GREEN;
+import static seedu.address.ui.Styles.CHANGE_COLOUR;
+import static seedu.address.ui.Styles.CLOSING_INLINE;
+import static seedu.address.ui.Styles.GREEN;
+import static seedu.address.ui.Styles.GREY;
+import static seedu.address.ui.Styles.RED;
+import static seedu.address.ui.Styles.WHITE_FONT_INLINE;
+import static seedu.address.ui.Styles.YELLOW;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -29,13 +38,6 @@ import seedu.address.model.candidate.InterviewStatus;
 public class FocusCard extends UiPart<Region> {
 
     private static final String FXML = "FocusListCard.fxml";
-    private static final String RED = "#800000";
-    private static final String GREEN = "#006100";
-    private static final String YELLOW = "#8B8000";
-    private static final String GREY = "#808080";
-    private static final String BRIGHT_GREEN = "#227F0F";
-    private static final String WHITE_STYLE = "-fx-text-fill: #FFFFFF;";
-    private static final String CHANGE_COLOUR = "-fx-background-color: ";
     private static final String BLANK_PICTURE_PATH = "docs/images/blankprofile.png";
 
     /**
@@ -140,7 +142,7 @@ public class FocusCard extends UiPart<Region> {
             interviewLabel.setStyle(CHANGE_COLOUR + GREEN);
             statusFocusPane.getChildren().add(interviewLabel);
         } else if (interviewString.equals(SCHEDULED)) {
-            interviewLabel.setStyle(CHANGE_COLOUR + YELLOW);
+            interviewLabel.setStyle(CHANGE_COLOUR + BLUE);
             statusFocusPane.getChildren().add(interviewLabel);
         }
     }
@@ -148,8 +150,8 @@ public class FocusCard extends UiPart<Region> {
     public void setAvailableDays(Availability availability) {
         String[] week = Availability.WEEK;
         boolean[] isAvail = availability.getAvailableListAsBoolean();
-        String availStyle = CHANGE_COLOUR + BRIGHT_GREEN + ";" + WHITE_STYLE;
-        String notAvailStyle = CHANGE_COLOUR + GREY + ";" + WHITE_STYLE;
+        String availStyle = CHANGE_COLOUR + BRIGHT_GREEN + CLOSING_INLINE + WHITE_FONT_INLINE;
+        String notAvailStyle = CHANGE_COLOUR + GREY + CLOSING_INLINE + WHITE_FONT_INLINE;
 
         for (int i = 0; i < week.length; i++) {
             Label label = new Label(week[i]);

--- a/src/main/java/seedu/address/ui/FocusCard.java
+++ b/src/main/java/seedu/address/ui/FocusCard.java
@@ -23,10 +23,6 @@ import seedu.address.model.candidate.Availability;
 import seedu.address.model.candidate.Candidate;
 import seedu.address.model.candidate.InterviewStatus;
 
-
-
-
-
 /**
  * An UI component that displays information of a {@code Candidate}.
  */
@@ -36,8 +32,9 @@ public class FocusCard extends UiPart<Region> {
     private static final String RED = "#800000";
     private static final String GREEN = "#006100";
     private static final String YELLOW = "#8B8000";
-    private static final String BRIGHT_GREEN = "#4BB11F";
     private static final String GREY = "#808080";
+    private static final String BRIGHT_GREEN = "#227F0F";
+    private static final String WHITE_STYLE = "-fx-text-fill: #FFFFFF;";
     private static final String CHANGE_COLOUR = "-fx-background-color: ";
     private static final String BLANK_PICTURE_PATH = "docs/images/blankprofile.png";
 
@@ -96,9 +93,7 @@ public class FocusCard extends UiPart<Region> {
         setApplicationStatus(candidate.getApplicationStatus());
         setInterviewStatus(candidate.getInterviewStatus());
         setAvailableDays(candidate.getAvailability());
-
     }
-
 
     @Override
     public boolean equals(Object other) {
@@ -153,16 +148,18 @@ public class FocusCard extends UiPart<Region> {
     public void setAvailableDays(Availability availability) {
         String[] week = Availability.WEEK;
         boolean[] isAvail = availability.getAvailableListAsBoolean();
+        String availStyle = CHANGE_COLOUR + BRIGHT_GREEN + ";" + WHITE_STYLE;
+        String notAvailStyle = CHANGE_COLOUR + GREY + ";" + WHITE_STYLE;
 
         for (int i = 0; i < week.length; i++) {
             Label label = new Label(week[i]);
+
             if (isAvail[i]) {
-                label.setStyle(CHANGE_COLOUR + BRIGHT_GREEN);
+                label.setStyle(availStyle);
             } else {
-                label.setStyle(CHANGE_COLOUR + GREY);
+                label.setStyle(notAvailStyle);
             }
             availableDaysFocus.getChildren().add(label);
         }
     }
-
 }

--- a/src/main/java/seedu/address/ui/FocusCard.java
+++ b/src/main/java/seedu/address/ui/FocusCard.java
@@ -7,6 +7,7 @@ import static seedu.address.model.candidate.ApplicationStatus.REJECTED_STATUS;
 import static seedu.address.model.candidate.InterviewStatus.COMPLETED;
 import static seedu.address.model.candidate.InterviewStatus.NOT_SCHEDULED;
 import static seedu.address.model.candidate.InterviewStatus.SCHEDULED;
+import static seedu.address.ui.Styles.AVAILABILITY_ID;
 import static seedu.address.ui.Styles.BLUE;
 import static seedu.address.ui.Styles.BRIGHT_GREEN;
 import static seedu.address.ui.Styles.CHANGE_COLOUR;
@@ -156,6 +157,8 @@ public class FocusCard extends UiPart<Region> {
 
         for (int i = 0; i < week.length; i++) {
             Label label = new Label(week[i]);
+            label.setId(AVAILABILITY_ID);
+            label.setMinWidth(30);
 
             if (isAvail[i]) {
                 label.setStyle(availStyle);

--- a/src/main/java/seedu/address/ui/FocusCard.java
+++ b/src/main/java/seedu/address/ui/FocusCard.java
@@ -39,6 +39,7 @@ public class FocusCard extends UiPart<Region> {
 
     private static final String FXML = "FocusListCard.fxml";
     private static final String BLANK_PICTURE_PATH = "docs/images/blankprofile.png";
+    private static final String SENIORITY_VALUE = "COM";
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -90,7 +91,7 @@ public class FocusCard extends UiPart<Region> {
         name.setText(candidate.getName().fullName);
         phone.setText(candidate.getPhone().value);
         email.setText(candidate.getEmail().value);
-        course.setText(candidate.getCourse().course + ", " + candidate.getSeniority().seniority);
+        course.setText(candidate.getCourse().course + ", " + SENIORITY_VALUE + candidate.getSeniority().seniority);
         displayPicture.setImage(new Image(new FileInputStream(BLANK_PICTURE_PATH)));
         setApplicationStatus(candidate.getApplicationStatus());
         setInterviewStatus(candidate.getInterviewStatus());

--- a/src/main/java/seedu/address/ui/Styles.java
+++ b/src/main/java/seedu/address/ui/Styles.java
@@ -1,0 +1,21 @@
+package seedu.address.ui;
+
+/**
+ * A constants file to hold CSS styles for *.java files.
+ */
+public class Styles {
+    // Colours
+    public static final String RED = "#800000";
+    public static final String GREEN = "#006100";
+    public static final String BLUE = "#3F7BCD";
+    public static final String YELLOW = "#9D7A02";
+    public static final String GREY = "#808080";
+    public static final String BRIGHT_GREEN = "#227F0F";
+
+    // Font Style
+    public static final String WHITE_FONT_INLINE = "-fx-text-fill: #FFFFFF;";
+    public static final String CHANGE_COLOUR = "-fx-background-color: ";
+
+    // Misc
+    public static final String CLOSING_INLINE = ";";
+}

--- a/src/main/java/seedu/address/ui/Styles.java
+++ b/src/main/java/seedu/address/ui/Styles.java
@@ -18,4 +18,5 @@ public class Styles {
 
     // Misc
     public static final String CLOSING_INLINE = ";";
+    public static final String AVAILABILITY_ID = "availabilityTag";
 }

--- a/src/main/resources/view/CandidateListCard.fxml
+++ b/src/main/resources/view/CandidateListCard.fxml
@@ -34,7 +34,7 @@
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       <HBox spacing="5" alignment="CENTER_LEFT">
         <Label fx:id="availability" styleClass="cell_small_label" text="\$availability" minWidth="30"/>
-        <FlowPane fx:id="availableDays" prefWrapLength="200"/>
+        <FlowPane fx:id="availableDays" prefWrapLength="300"/>
       </HBox>
     </VBox>
   </GridPane>

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -351,6 +351,14 @@
     -fx-font-size: 11;
 }
 
+#availableDays #availabilityTag {
+    -fx-alignment: center;
+}
+
+#availableDaysFocus #availabilityTag {
+    -fx-alignment: center;
+}
+
 #statusPane {
     -fx-hgap: 7;
     -fx-vgap: 10;
@@ -381,7 +389,6 @@
     -fx-hgap: 7;
     -fx-vgap: 10;
     -fx-padding: 2 3 2 3;
-
 }
 
 #statusFocusPane .label {
@@ -396,7 +403,6 @@
     -fx-hgap: 7;
     -fx-vgap: 3;
     -fx-padding: 2 3 2 3;
-
 }
 
 #availableDaysFocus .label {
@@ -410,7 +416,6 @@
 
 #focusSplitPane {
     -fx-padding: 0 0 10 0;
-
 }
 
 .focusStyle {

--- a/src/main/resources/view/FocusListCard.fxml
+++ b/src/main/resources/view/FocusListCard.fxml
@@ -22,7 +22,7 @@
                     <Label fx:id="name" styleClass="focusStyleName" text="\$phone" />
                     <Label fx:id="id" styleClass="focusStyleName" text="\$id" />
                     <FlowPane fx:id="statusFocusPane" prefWrapLength="200"/>
-                    <FlowPane fx:id="availableDaysFocus" prefWrapLength="200"/>
+                    <FlowPane fx:id="availableDaysFocus" prefWrapLength="300"/>
                 </VBox>
             </SplitPane>
             <Label fx:id="phone" styleClass="focusStyle" text="\$phone" />


### PR DESCRIPTION
This PR consists of the following changes:
- Shift constants style related codes to a separate file to import from
- Update UI of `availability` tags
- Add a new `primary` colour of `blue` for `Scheduled` of `interviewStatus`
- Fix command message for `focus` command
- Fix missing `COM` tag for `seniority` in `FocusCard`

<hr>

<h4>Current UI</h4>
<p><b>Note: Window resized manually. Will have to change to new dimensions preset preferences</b></p>
<img src="https://user-images.githubusercontent.com/46486515/160292833-ffafe091-e427-46fc-b1b5-0adb81c8038b.png" />

<hr>

Closes #178.