### PR TITLE
Issue #190: Fix split pane overflow scroll and headers

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -53,7 +53,7 @@ public class MainApp extends Application {
 
     @Override
     public void init() throws Exception {
-        logger.info("=============================[ Initializing AddressBook ]===========================");
+        logger.info("=============================[ Initializing TalentAssistant ]===========================");
         super.init();
 
         AppParameters appParameters = AppParameters.parse(getParameters());
@@ -89,7 +89,7 @@ public class MainApp extends Application {
             addressBookOptional = storage.readAddressBook();
             interviewListOptional = storage.readInterviewSchedule();
             if (!addressBookOptional.isPresent()) {
-                logger.info("Data file not found. Will be starting with a sample AddressBook");
+                logger.info("Data file not found. Will be starting with a sample TalentAssistant");
             }
             initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
             //Does not make sense for sample interview list. Change to empty list
@@ -98,11 +98,11 @@ public class MainApp extends Application {
             }
             initialInterviewList = interviewListOptional.orElseGet(SampleDataUtil::getEmptyInterviewList);
         } catch (DataConversionException e) {
-            logger.warning("Data file not in the correct format. Will be starting with an empty AddressBook");
+            logger.warning("Data file not in the correct format. Will be starting with an empty TalentAssistant");
             initialData = new AddressBook();
             initialInterviewList = new InterviewSchedule();
         } catch (IOException e) {
-            logger.warning("Problem while reading from the file. Will be starting with an empty AddressBook");
+            logger.warning("Problem while reading from the file. Will be starting with an empty TalentAssistant");
             initialData = new AddressBook();
             initialInterviewList = new InterviewSchedule();
         }
@@ -190,7 +190,7 @@ public class MainApp extends Application {
 
     @Override
     public void stop() {
-        logger.info("============================ [ Stopping Address Book ] =============================");
+        logger.info("============================ [ Stopping TalentAssistant ] =============================");
         try {
             storage.saveUserPrefs(model.getUserPrefs());
         } catch (IOException e) {

--- a/src/main/java/seedu/address/commons/core/GuiSettings.java
+++ b/src/main/java/seedu/address/commons/core/GuiSettings.java
@@ -10,8 +10,8 @@ import java.util.Objects;
  */
 public class GuiSettings implements Serializable {
 
-    private static final double DEFAULT_HEIGHT = 600;
-    private static final double DEFAULT_WIDTH = 740;
+    private static final double DEFAULT_HEIGHT = 800;
+    private static final double DEFAULT_WIDTH = 1200;
 
     private final double windowWidth;
     private final double windowHeight;

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -431,6 +431,40 @@
     -fx-padding: 10 10 10 0;
 }
 
+// ************* candidate panel header css *************
+.candidate-panel-header {
+    -fx-background-color: #3c3e3f;
+}
+
+.candidate-panel-title {
+    -fx-font-size: 16px;
+    -fx-text-fill: white;
+    -fx-font-family: "Segoe UI Light";
+}
+
+// ************* focus panel header css *************
+.focus-panel-header {
+    -fx-background-color: #3c3e3f;
+}
+
+.focus-panel-title {
+    -fx-font-size: 16px;
+    -fx-text-fill: white;
+    -fx-font-family: "Segoe UI Light";
+}
+
+#focus-card-label {
+    -fx-padding: 0 0 0 15;
+}
+
+#focus-card-scroll-pane {
+    -fx-background-color: #3c3e3f;
+    -fx-border-width: 0;
+}
+
+#focus-card-scroll-pane > .viewport {
+    -fx-background-color: #3c3e3f;
+}
 
 // ************* interview panel css *************
 .interview-panel-header {

--- a/src/main/resources/view/FocusListCard.fxml
+++ b/src/main/resources/view/FocusListCard.fxml
@@ -7,27 +7,38 @@
 <?import javafx.scene.layout.VBox?>
 
 <?import javafx.scene.image.ImageView?>
-<?import javafx.scene.layout.StackPane?>
-<?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.layout.FlowPane?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.ScrollPane?>
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-    <GridPane HBox.hgrow="ALWAYS">
-        <columnConstraints>
-            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
-        </columnConstraints>
-        <VBox alignment="CENTER_LEFT" minHeight="120" GridPane.columnIndex="0">
-            <SplitPane fx:id="focusSplitPane">
-                <ImageView fx:id="displayPicture" fitWidth="120" fitHeight="120"/>
-                <VBox fx:id="keyAttributes" styleClass="keyAttributesVBox" VBox.vgrow="ALWAYS">
-                    <Label fx:id="name" styleClass="focusStyleName" text="\$phone" />
-                    <Label fx:id="id" styleClass="focusStyleName" text="\$id" />
-                    <FlowPane fx:id="statusFocusPane" prefWrapLength="200"/>
-                    <FlowPane fx:id="availableDaysFocus" prefWrapLength="200"/>
-                </VBox>
-            </SplitPane>
-            <Label fx:id="phone" styleClass="focusStyle" text="\$phone" />
-            <Label fx:id="email" styleClass="focusStyle" text="\$email" />
-            <Label fx:id="course" styleClass="focusStyle" text="\$course" />
-        </VBox>
-    </GridPane>
+        <ScrollPane id="focus-card-scroll-pane" VBox.vgrow="ALWAYS" minHeight="200" HBox.hgrow="ALWAYS" hbarPolicy="AS_NEEDED">
+            <VBox HBox.hgrow="ALWAYS">
+                <GridPane HBox.hgrow="ALWAYS" minWidth="300">
+                    <padding>
+                        <Insets bottom="15" />
+                    </padding>
+                    <columnConstraints>
+                        <ColumnConstraints hgrow="SOMETIMES" minWidth="120" prefWidth="150" />
+                    </columnConstraints>
+                    <VBox alignment="CENTER" minHeight="150" minWidth="120" GridPane.columnIndex="0">
+                        <ImageView fx:id="displayPicture" fitWidth="120" fitHeight="120"/>
+                    </VBox>
+                    <padding>
+                        <Insets bottom="15" />
+                    </padding>
+                    <columnConstraints>
+                        <ColumnConstraints hgrow="SOMETIMES" minWidth="200" prefWidth="200" maxWidth="250"/>
+                    </columnConstraints>
+                    <VBox fx:id="keyAttributes" styleClass="keyAttributesVBox" alignment="CENTER_LEFT" minWidth="100" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS" GridPane.columnIndex="1">
+                        <Label fx:id="name" styleClass="focusStyleName" text="\$phone" />
+                        <Label fx:id="id" styleClass="focusStyleName" text="\$id" />
+                        <FlowPane fx:id="statusFocusPane" prefWrapLength="200"/>
+                        <FlowPane fx:id="availableDaysFocus" prefWrapLength="200"/>
+                    </VBox>
+                </GridPane>
+                <Label id="focus-card-label" fx:id="phone" styleClass="focusStyle" text="\$phone" />
+                <Label id="focus-card-label" fx:id="email" styleClass="focusStyle" text="\$email" />
+                <Label id="focus-card-label" fx:id="course" styleClass="focusStyle" text="\$course" />
+            </VBox>
+        </ScrollPane>
 </HBox>

--- a/src/main/resources/view/InterviewListCard.fxml
+++ b/src/main/resources/view/InterviewListCard.fxml
@@ -11,7 +11,7 @@
 <HBox id="interviewCard" fx:id="interviewCard" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <GridPane HBox.hgrow="ALWAYS">
         <columnConstraints>
-            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="80" />
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="70" />
         </columnConstraints>
         <VBox alignment="CENTER_LEFT" minHeight="70" GridPane.columnIndex="0">
             <padding>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -42,31 +42,47 @@
         </StackPane>
 
         <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                   minHeight="100" prefHeight="100" maxHeight="100">
+                   minHeight="120" prefHeight="120" maxHeight="120">
           <padding>
             <Insets top="5" right="10" bottom="5" left="10" />
           </padding>
         </StackPane>
 
-        <SplitPane fx:id="splitPanePlaceholder" VBox.vgrow="ALWAYS">
+        <SplitPane fx:id="splitPanePlaceholder" VBox.vgrow="ALWAYS" dividerPositions="0.35, 0.70">
           <items>
             <VBox fx:id="candidateList" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
               <padding>
-                <Insets top="10" right="10" bottom="10" left="10" />
+                <Insets top="5" right="5" bottom="5" left="5" />
               </padding>
-              <StackPane fx:id="candidateListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+              <HBox styleClass="candidate-panel-header" HBox.hgrow="ALWAYS" minHeight="40" prefHeight="40" alignment="CENTER">
+                <Label styleClass="candidate-panel-title" alignment="CENTER" text="Candidates List" />
+              </HBox>
+              <VBox VBox.vgrow="ALWAYS">
+                <padding>
+                  <Insets top="10" right="10" bottom="10" left="10" />
+                </padding>
+                <StackPane fx:id="candidateListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+              </VBox>
             </VBox>
             <VBox fx:id="focusList" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
               <padding>
-                <Insets top="10" right="10" bottom="10" left="10" />
+                <Insets top="5" right="5" bottom="5" left="5" />
               </padding>
-              <StackPane fx:id="focusListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+              <HBox styleClass="focus-panel-header" HBox.hgrow="ALWAYS" minHeight="40" prefHeight="40" alignment="CENTER">
+                <Label styleClass="focus-panel-title" alignment="CENTER" text="Focused Display" />
+              </HBox>
+              <VBox VBox.vgrow="ALWAYS">
+                <padding>
+                  <Insets top="10" right="10" bottom="10" left="10" />
+                </padding>
+                <StackPane fx:id="focusListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+              </VBox>
             </VBox>
             <VBox fx:id="interviewList" styleClass="pane-with-border" prefHeight="340" VBox.vgrow="ALWAYS" >
               <padding>
                 <Insets top="5" right="5" bottom="5" left="5" />
               </padding>
-              <HBox styleClass="interview-panel-header" HBox.hgrow="ALWAYS" minHeight="30" prefHeight="40" alignment="CENTER">
+              <HBox styleClass="interview-panel-header" HBox.hgrow="ALWAYS" minHeight="40" prefHeight="40" alignment="CENTER">
                 <Label styleClass="interview-panel-title" alignment="CENTER" text="Scheduled Interviews" />
               </HBox>
               <VBox VBox.vgrow="ALWAYS">


### PR DESCRIPTION
Currently, minimising the screen will cause some text misalignment and truncation of information.

This might affect the user's ease of viewing.

Let's include the following changes:
* a scroll pane in the middle panel to allow overflow scrolling
* headers for each panel to indicate each panel's use
* larger default window size for the gui app
* extend the feedback box to have a larger minimum height

<br> **Previous UI upon minimisation:**
![Screenshot 2022-03-28 at 2 27 59 AM](https://user-images.githubusercontent.com/65525578/160326553-36eca8a9-5c7a-4777-9664-1ade0abf4485.png)


<br> **Updated UI upon minimisation:**
<img width="917" alt="Screenshot 2022-03-28 at 12 16 57 PM" src="https://user-images.githubusercontent.com/65525578/160326568-f13baa52-b018-4e79-be50-65d7b331f8aa.png">


_Note to reviewers: appreciate your help to double check the default viewing dimensions! :) Feel free to leave comments on removing/modifying any of the above changes, or modifying them at your end after the merge!_

Closes #190 