### PR TITLE
#203-Remove `InterviewStatus` Trigger

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -10,9 +10,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SENIORITY;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CANDIDATES;
-import static seedu.address.model.candidate.ApplicationStatus.ACCEPTED_STATUS;
-import static seedu.address.model.candidate.ApplicationStatus.REJECTED_STATUS;
-import static seedu.address.model.candidate.InterviewStatus.COMPLETED;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -239,7 +239,6 @@ public class EditCommand extends Command {
 
         public void setApplicationStatus(ApplicationStatus applicationStatus) {
             this.applicationStatus = applicationStatus;
-            triggerInterviewStatus(applicationStatus);
         }
 
         public Optional<ApplicationStatus> getApplicationStatus() {
@@ -305,17 +304,5 @@ public class EditCommand extends Command {
                     && getAvailability().equals(e.getAvailability());
         }
 
-
-        /**
-         * Allows the {@code InterviewStatus} to be triggered by ApplicationStatus.
-         */
-        public void triggerInterviewStatus(ApplicationStatus applicationStatus) {
-            if (getApplicationStatus().isPresent()) {
-                if (applicationStatus.toString().equals(ACCEPTED_STATUS)
-                        || applicationStatus.toString().equals(REJECTED_STATUS)) {
-                    setInterviewStatus(new InterviewStatus(COMPLETED));
-                }
-            }
-        }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -159,24 +159,6 @@ public class EditCommandTest {
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_CANDIDATE_DISPLAYED_INDEX);
     }
 
-    @Test
-    public void execute_trigger_success() {
-        EditCandidateDescriptor editCandidateDescriptor = new EditCandidateDescriptorBuilder()
-                .withName(VALID_NAME_BOB)
-                .withApplicationStatus(VALID_APPLICATION_PENDING)
-                .withInterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED)
-                .build();
-        assertEquals(editCandidateDescriptor.getApplicationStatus().get(),
-                new ApplicationStatus(VALID_APPLICATION_PENDING));
-        assertEquals(editCandidateDescriptor.getInterviewStatus().get(),
-                new InterviewStatus(VALID_INTERVIEW_NOT_SCHEDULED));
-
-        editCandidateDescriptor.setApplicationStatus(new ApplicationStatus(VALID_APPLICATION_ACCEPTED));
-        assertEquals(editCandidateDescriptor.getApplicationStatus().get(),
-                new ApplicationStatus(VALID_APPLICATION_ACCEPTED));
-        assertEquals(editCandidateDescriptor.getInterviewStatus().get(),
-                new InterviewStatus(VALID_INTERVIEW_COMPLETED));
-    }
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
@@ -30,9 +29,7 @@ import seedu.address.model.InterviewSchedule;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.candidate.ApplicationStatus;
 import seedu.address.model.candidate.Candidate;
-import seedu.address.model.candidate.InterviewStatus;
 import seedu.address.testutil.CandidateBuilder;
 import seedu.address.testutil.EditCandidateDescriptorBuilder;
 


### PR DESCRIPTION
Currently `InterviewStatus` will be triggered to `Completed` once `ApplicationStatus` is set to `Accepted` or `Rejected`. 
Let's decouple the two status to make them independent. 

Closes #203 