### PR TITLE
#212-Remove attributes displayed on `Candidate List`

### DIFF
--- a/src/main/java/seedu/address/ui/CandidateCard.java
+++ b/src/main/java/seedu/address/ui/CandidateCard.java
@@ -56,14 +56,6 @@ public class CandidateCard extends UiPart<Region> {
     @FXML
     private Label id;
     @FXML
-    private Label phone;
-    @FXML
-    private Label course;
-    @FXML
-    private Label email;
-    @FXML
-    private Label availability;
-    @FXML
     private FlowPane tags;
     @FXML
     private FlowPane statusPane;
@@ -77,10 +69,6 @@ public class CandidateCard extends UiPart<Region> {
         this.candidate = candidate;
         id.setText(displayedIndex + ". ");
         name.setText(candidate.getName().fullName + ", " + candidate.getStudentId().studentId);
-        phone.setText(candidate.getPhone().value);
-        course.setText(candidate.getCourse().course + ", " + SENIORITY_VALUE + candidate.getSeniority().seniority);
-        email.setText(candidate.getEmail().value);
-        availability.setText(AVAILABILITY_MSG);
 
         setAvailableDays(candidate.getAvailability());
         setApplicationStatus(candidate.getApplicationStatus());

--- a/src/main/resources/view/CandidateListCard.fxml
+++ b/src/main/resources/view/CandidateListCard.fxml
@@ -27,15 +27,9 @@
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
-      <FlowPane fx:id="statusPane" prefWrapLength="200"/>
-      <FlowPane fx:id="tags" />
-      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-      <Label fx:id="course" styleClass="cell_small_label" text="\$course" />
-      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-      <HBox spacing="5" alignment="CENTER_LEFT">
-        <Label fx:id="availability" styleClass="cell_small_label" text="\$availability" minWidth="30"/>
-        <FlowPane fx:id="availableDays" prefWrapLength="300"/>
-      </HBox>
+      <FlowPane fx:id="statusPane" prefWrapLength="200" styleClass="status_pane_style"/>
+      <FlowPane fx:id="tags"/>
+      <FlowPane fx:id="availableDays" prefWrapLength="300" styleClass="availability_pane_style" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -124,6 +124,15 @@
     -fx-font-family: "Segoe UI Semibold";
     -fx-font-size: 16px;
     -fx-text-fill: #010504;
+    -fx-padding: 2 0 2 0;
+}
+
+.status_pane_style {
+    -fx-padding: 2 0 2 0;
+}
+
+.availability_pane_style {
+    -fx-padding: 5 0 0 0;
 }
 
 .cell_small_label {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -42,7 +42,7 @@
         </StackPane>
 
         <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                   minHeight="120" prefHeight="120" maxHeight="120">
+                   minHeight="150" prefHeight="150" maxHeight="170">
           <padding>
             <Insets top="5" right="10" bottom="5" left="10" />
           </padding>


### PR DESCRIPTION
![Screenshot 2022-03-29 at 4 19 08 PM](https://user-images.githubusercontent.com/34470525/160566507-ab6fd4ba-4444-4f01-b1ef-4992784195ab.png)

- Currently only displays `name`, `studentId`, `availability` and `statuses`
- Expanded the result box to `150`

closes #212 