### PR TITLE
Issue #240: Address issues relating to `sort`, `find`, `remark` and UI

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -211,7 +211,7 @@ Format: `sort s/ATTRIBUTE_FIELD`
 **:information_source: Notes about the edit format:**<br>
 
 `ATTRIBUTE_FIELD` can take on the following values
-`as`, `course`, `email`, `is`, `name`, `phone`, `yr`, `id`
+`appstatus`, `course`, `intstatus`, `name`, `seniority`, `studentid`
 
 </div>
 
@@ -220,7 +220,7 @@ Format: `sort s/ATTRIBUTE_FIELD`
   (i.e. A-Z, 0-9) with regard to the specified attribute field.
 
 Examples:
-Let's reference a default sample list of unique candidates with attribute fields stated as (`name`, `id`).
+Let's reference a default sample list of unique candidates with attribute fields stated as (`name`, `studentid`).
 1. (`Ben`, `A5588565L`)
 2. (`Alice`, `A2344567B`)
 3. (`Charlie`, `A0188565L`)
@@ -230,7 +230,7 @@ Let's reference a default sample list of unique candidates with attribute fields
 2. (`Ben`, `A5588565L`)
 3. (`Charlie`, `A0188565L`)
 
-`sort s/id` returns candidates sorted by name in the following order:
+`sort s/studentid` returns candidates sorted by name in the following order:
 1. (`Charlie`, `A0188565L`)
 2. (`Alice`, `A2344567B`)
 3. (`Ben`, `A5588565L`)

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -4,7 +4,7 @@ title: User Guide
 ---
 
 TAlent Assistant™ is a **desktop, lightweight and centralized management system** catered to professors for managing
-the interview scheduling process of candidates applying to be undergraduate/graduate Teaching Assistants (TA). 
+the interview scheduling process of candidates applying to be undergraduate Teaching Assistants (TA). 
 Professors will be able to access the candidates’ application data easily and review their general availability for 
 scheduling interviews during office hours.
 TAlent Assistant™ is **optimized for use via a Command Line Interface (CLI)** while still having the benefits of a 
@@ -28,22 +28,24 @@ faster than traditional GUI applications.
 1. Double-click the file to start the app. The GUI similar to the below should appear in a few seconds. Note how the app contains some sample data.<br>
    ![Ui](images/Ui.png)
 
-1. Type the command in the command box and press `Enter` to execute it. e.g. typing **`help`** and pressing `Enter` will open the help window.<br>
+1. Type the command in the command box and press Enter to execute it. e.g. typing **`help`** and pressing Enter will open the help window.<br>
    Some example commands you can try:
 
     * **`list`** : Lists all candidates.
 
     * **`add id/A0123456B n/John Doe p/87654321 e/E0123456@u.nus.edu c/Computer Science yr/2 avail/1,2,3`** Adds a new candidate into the system.
    
-    * **`edit 1 c/Computer Science yr/3 avail/1 ...`** Edits the first candidate in the system.
+    * **`edit 1 c/Computer Science yr/3 avail/1 ...`** Edits the first candidate displayed in the system.
 
-    * **`delete 1`** : Deletes the first candidate in the system.
+    * **`delete 1`** : Deletes the first candidate displayed in the system.
 
-    * **`find k/Alex f/name`** : Searches for all candidate with name containing “alex" (case-insensitive).
+    * **`find k/Alex f/name`** : Searches for all candidates with name containing “alex" (case-insensitive).
 
     * **`sort s/name`** : Sorts all candidates by name in ascending alphabetical order (i.e. A-Z).
     
     * **`view today`** : Filters all interviews to display only interviews scheduled today (if any).
+   
+    * **`remark 1 r/a good candidate`** : Adds a remark to the first candidate displayed in the system.
    
     * **`schedule add candidate/1 at/05-05-2022 10:00`** : Schedules the first candidate for an interview at 5 May 2022 10AM.
 
@@ -68,11 +70,11 @@ faster than traditional GUI applications.
 
 * **Candidates List** : Bottom leftmost panel displays the list of candidates in the system, alongside some key information.
 
-* **Candidate Profile** : Bottom middle panel brings up a focused view of the candidate's profile when the related command is entered.
+* **Candidate Profile** : Bottom middle panel brings up a focused view of the candidate's profile when the related `focus` command is entered.
 
 * **Scheduled Interviews** : Bottom rightmost panel displays the list of scheduled interviews.
 
-Commands that affect the display of information within each of these panels is described below.
+Features relating to the display of information within these panels are described below.
 
 </div>
 
@@ -99,14 +101,14 @@ Commands that affect the display of information within each of these panels is d
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 
-* The following table lists some common abbreviations used in `ATTRIBUTE_FIELD`s.
+* The following table lists some common abbreviations used in the command prefixes or `ATTRIBUTE_FIELD`s.
 
-| `ATTRIBUTE_FIELD` | Refers to           |
-|-------------------|---------------------|
-| `is`              | interview status    |
-| `as`              | application status  |
-| `yr`              | seniority           |
-| `avail`           | availability        |
+| Abbreviation(s)     | Refer(s) to        |
+|---------------------|--------------------|
+| `is` or `intstatus` | interview status   |
+| `as` or `appstatus` | application status |
+| `yr`                | seniority          |
+| `avail`             | availability       |
 
 </div>
 
@@ -149,8 +151,6 @@ Format: `edit INDEX c/COURSE yr/YEAR [ATTRIBUTE_FIELD/VALUE]...`
 
 `ATTRIBUTE_FIELD` can take on the following values `id`, `name`, `email`, `phone`, `course`, `yr`, `as`, `avail`
 
-* `as` is short for `ApplicationStatus`.
-
 </div>
 
 * Edits the candidate at the specified `INDEX`. The index refers to the index number shown in the displayed candidate list. The index **must be a positive integer** 1, 2, 3, …​
@@ -168,6 +168,7 @@ Displays all candidates found in the system.
 
 Format: `list`
 
+
 ### Finding candidates by keyword(s) search: `find`
 
 Finds and lists candidates whose attribute field(s) contain(s) any of the given keyword(s).
@@ -179,10 +180,10 @@ Format: `find k/KEYWORD [k/MORE_KEYWORDS]... f/ATTRIBUTE_FIELD`
 **:information_source: Notes about the find format:**<br>
 
 `ATTRIBUTE_FIELD` can take on the following values 
-`as`, `course`, `email`, `is`, `name`, `phone`, `yr`, `id`, `all`, `avail`
+`appstatus`, `course`, `email`, `intstatus`, `name`, `phone`, `seniority`, `studentid`, `all`, `avail`
 
 Note: 
-`yr` may match any case variation of `COM1`, `COM2`, `COM3` or `COM4`
+`seniority` may match any case variation of `COM1`, `COM2`, `COM3` or `COM4`
 `avail` may match any case variation of days in the format of `MON`, `TUE`, `WED`, `THUR` or `FRI`
 
 </div>
@@ -196,6 +197,7 @@ Note:
 * Candidates matching at least one full keyword (in the specified attribute field) will be returned i.e. OR search,
   e.g. `k/Jane k/Doe f/name` will return candidates with name e.g. `Jane Koe`, `John Doe`
 * If multiple `ATTRIBUTE_FIELD`s are provided, only the last field will be used.
+* If no `ATTRIBUTE_FIELD` is provided, the search will be conducted across all fields by default.
 
 Examples:
 * `find k/Jane f/name` returns candidates with name e.g. `jane` and `jane doe`
@@ -232,36 +234,32 @@ Let's reference a default sample list of unique candidates with attribute fields
 2. (`Ben`, `A5588565L`)
 3. (`Charlie`, `A0188565L`)
 
-`sort s/studentid` returns candidates sorted by name in the following order:
+`sort s/studentid` returns candidates sorted by student id in the following order:
 1. (`Charlie`, `A0188565L`)
 2. (`Alice`, `A2344567B`)
 3. (`Ben`, `A5588565L`)
 
-### Viewing scheduled interviews `view`
 
-Returns the list of scheduled interviews within the specified time period.
+### Updating a candidate's remarks: `remark`
 
-Format: `view TIME_PERIOD`
+Updates the `remark` field of a candidate to the user input keyed in.
+
+Format: `remark INDEX r/REMARK`
 
 <div markdown="block" class="alert alert-info">
 
 **:information_source: Notes about the edit format:**<br>
 
-`TIME_PERIOD` can take on the following values `all`, `today`, `week`, `month`
+`INDEX` must be non-negative
 
 </div>
 
-* The attribute field is case-insensitive. e.g. `ALL` is equivalent to `all`
-* Scheduled interviews are automatically sorted from earliest to latest
+* To remove the remark of the first candidate displayed in the system, the user can simply key in `remark 1 r/`, 
+which will update the remark of the candidate to be empty.
 
 Examples:
-
-| Example command | Expected Behaviour                                                               |
-|-----------------|----------------------------------------------------------------------------------|
-| `view all`      | returns all scheduled interviews still in system whether in the past or upcoming |
-| `view today`    | returns all scheduled interviews on the same date as the current time            |
-| `view week`     | returns all upcoming scheduled interviews within the next 7 days                 |
-| `view month`    | returns all upcoming scheduled interviews within the next month                  |
+* `remark 1 r/a good candidate` Updates the candidate's remark field to reflect 'a good candidate'.
+* `remark 1 r/` Removes the candidate's remark field to reflect ''.
 
 ### Deleting a candidate : `delete`
 
@@ -318,7 +316,7 @@ Format: `schedule edit SCHEDULE_INDEX at/DATE_TIME`
 * `DATE_TIME` must not be earlier than the present date and time.
 
 Examples:
-* `view` followed by `schedule edit 2 at/06-06-2022 15:00` reschedules the second interview in the interview schedule
+* `view all` followed by `schedule edit 2 at/06-06-2022 15:00` reschedules the second interview in the interview schedule
   to 6 June 2022 3PM.
 
 ### Deleting an interview: `schedule delete`
@@ -332,7 +330,33 @@ Format: `schedule delete SCHEDULE_INDEX`
 * The schedule index must be a positive integer 1, 2, 3, …​
 
 Examples:
-* `view` followed by `schedule delete 2` deletes the second interview in the interview schedule.
+* `view all` followed by `schedule delete 2` deletes the second interview in the interview schedule.
+
+### Viewing scheduled interviews `view`
+
+Returns the list of scheduled interviews within the specified time period.
+
+Format: `view TIME_PERIOD`
+
+<div markdown="block" class="alert alert-info">
+
+**:information_source: Notes about the edit format:**<br>
+
+`TIME_PERIOD` can take on the following values `all`, `today`, `week`, `month`
+
+</div>
+
+* The attribute field is case-insensitive. e.g. `ALL` is equivalent to `all`
+* Scheduled interviews are automatically sorted from earliest to latest
+
+Examples:
+
+| Example command | Expected Behaviour                                                               |
+|-----------------|----------------------------------------------------------------------------------|
+| `view all`      | returns all scheduled interviews still in system whether in the past or upcoming |
+| `view today`    | returns all scheduled interviews on the same date as the current time            |
+| `view week`     | returns all upcoming scheduled interviews within the next 7 days                 |
+| `view month`    | returns all upcoming scheduled interviews within the next month                  |
 
 ## Miscellaneous commands
 
@@ -387,6 +411,7 @@ Commands in this section have been organised based on the expected scope of beha
 | **Edit**   | `edit INDEX [n/NAME] [e/EMAIL] [p/PHONE_NUMBER] [c/COURSE] [yr/YEAR] [avail/AVAILABILITY] [as/APPLICATION_STATUS]…​`<br> e.g.,`edit 2 n/James Lee p/98765432 yr/4`                             |
 | **Find**   | `find k/KEYWORD [k/MORE_KEYWORDS]... f/ATTRIBUTE_FIELD`<br> e.g., `find k/Jane k/Doe f/name`                                                                                                   |
 | **Sort**   | `sort s/ATTRIBUTE_FIELD`<br> e.g., `sort s/name`                                                                                                                                               |
+| **Remark** | `remark INDEX r/REMARKS`<br> e.g., `remark 1 r/a good candidate`                                                                                                                               |
 
 ### Candidate Profile
 | Action    | Format, Examples |
@@ -399,7 +424,7 @@ Commands in this section have been organised based on the expected scope of beha
 | **Schedule interview**        | `schedule add candidate/INDEX /at DATE_TIME` <br> e.g., `schedule add candidate/2 at/05-05-2022 10:00` |
 | **Reschedule interview**      | `schedule edit SCHEDULE_INDEX at/DATE_TIME` <br> e.g., `schedule edit 1 at/06-06-2022 15:00`           |
 | **Delete interview**          | `schedule delete SCHEDULE_INDEX` <br> e.g., `schedule delete 1`                                        |
-| **View scheduled interviews** | `view TIME PERIOD` <br> e.g., `view all`, `view today`                                                 |
+| **View scheduled interviews** | `view TIME_PERIOD` <br> e.g., `view all`, `view today`                                                 |
 
 ### Miscellaneous commands / Help
 | Action    | Format, Examples |

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -23,8 +23,8 @@ public class SortCommand extends Command {
             + PREFIX_SORTKEY + " SORTKEY argument.\n"
             + "Parameters: " + PREFIX_SORTKEY + "SORTKEY \n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_SORTKEY + "name\n"
-            + "Allowable fields to be sorted by include: applicationstatus, availability, course, email, "
-            + "interviewstatus, name, phone, seniority, studentid.";
+            + "Allowable fields to be sorted by include: appstatus, course, "
+            + "intstatus, name, seniority, studentid.";
 
     private final Comparator<Candidate> sortComparator;
     private final String sortKey;

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -53,7 +53,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         switch (fieldString) {
-        case "as":
+        case "appstatus":
             return new FindCommand(new ApplicationStatusContainsKeywordsPredicate(keywords));
         case "avail":
             return new FindCommand(new AvailabilityContainsKeywordsPredicate(keywords));
@@ -64,15 +64,15 @@ public class FindCommandParser implements Parser<FindCommand> {
             return new FindCommand(new CourseContainsKeywordsPredicate(keywords));
         case "email":
             return new FindCommand(new EmailContainsKeywordsPredicate(keywords));
-        case "is":
+        case "intstatus":
             return new FindCommand(new InterviewStatusContainsKeywordsPredicate(keywords));
         case "name":
             return new FindCommand(new NameContainsKeywordsPredicate(keywords));
         case "phone":
             return new FindCommand(new PhoneContainsKeywordsPredicate(keywords));
-        case "yr":
+        case "seniority":
             return new FindCommand(new SeniorityContainsKeywordsPredicate(keywords));
-        case "id":
+        case "studentid":
             return new FindCommand(new StudentIdContainsKeywordsPredicate(keywords));
         default:
             return new FindCommand(new CandidateContainsKeywordsPredicate(Collections.<String>emptyList()));

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -34,28 +34,22 @@ public class SortCommandParser implements Parser<SortCommand> {
         Comparator<Candidate> sortComparator;
 
         switch (sortKey) {
-        case "as":
+        case "appstatus":
             sortComparator = Comparator.comparing(l -> l.getApplicationStatus().toString().toLowerCase());
             break;
         case "course":
             sortComparator = Comparator.comparing(l -> l.getCourse().toString().toLowerCase());
             break;
-        case "email":
-            sortComparator = Comparator.comparing(l -> l.getEmail().toString().toLowerCase());
-            break;
-        case "is":
+        case "intstatus":
             sortComparator = Comparator.comparing(l -> l.getInterviewStatus().toString().toLowerCase());
-            break;
-        case "phone":
-            sortComparator = Comparator.comparing(l -> l.getPhone().toString().toLowerCase());
             break;
         case "name":
             sortComparator = Comparator.comparing(l -> l.getName().toString().toLowerCase());
             break;
-        case "yr":
+        case "seniority":
             sortComparator = Comparator.comparing(l -> l.getSeniority().toString().toLowerCase());
             break;
-        case "id":
+        case "studentid":
             sortComparator = Comparator.comparing(l -> l.getStudentId().toString().toLowerCase());
             break;
         default:

--- a/src/main/java/seedu/address/ui/CandidateCard.java
+++ b/src/main/java/seedu/address/ui/CandidateCard.java
@@ -52,6 +52,8 @@ public class CandidateCard extends UiPart<Region> {
     @FXML
     private HBox cardPane;
     @FXML
+    private Label course;
+    @FXML
     private Label name;
     @FXML
     private Label id;
@@ -69,6 +71,7 @@ public class CandidateCard extends UiPart<Region> {
         this.candidate = candidate;
         id.setText(displayedIndex + ". ");
         name.setText(candidate.getName().fullName + ", " + candidate.getStudentId().studentId);
+        course.setText(candidate.getCourse().course + ", " + SENIORITY_VALUE + candidate.getSeniority().seniority);
 
         setAvailableDays(candidate.getAvailability());
         setApplicationStatus(candidate.getApplicationStatus());

--- a/src/main/java/seedu/address/ui/FocusCard.java
+++ b/src/main/java/seedu/address/ui/FocusCard.java
@@ -112,6 +112,8 @@ public class FocusCard extends UiPart<Region> {
             phone.setText(EMPTY_MESSAGE);
             email.setText(EMPTY_MESSAGE);
             course.setText(EMPTY_MESSAGE);
+            remark.setText(EMPTY_MESSAGE);
+
         } else {
             this.candidate = candidate;
             this.interview = interview;
@@ -120,6 +122,7 @@ public class FocusCard extends UiPart<Region> {
             phone.setText(candidate.getPhone().value);
             email.setText(candidate.getEmail().value);
             course.setText(candidate.getCourse().course + ", " + SENIORITY_VALUE + candidate.getSeniority().seniority);
+            remark.setText("Remarks (if any): " + candidate.getRemark().value);
             setProfilePicture(candidate.getName());
             setApplicationStatus(candidate.getApplicationStatus());
             setInterviewStatus(candidate.getInterviewStatus());

--- a/src/main/resources/view/CandidateListCard.fxml
+++ b/src/main/resources/view/CandidateListCard.fxml
@@ -27,8 +27,8 @@
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
+      <Label fx:id="course" styleClass="cell_small_label" text="\$course" />
       <FlowPane fx:id="statusPane" prefWrapLength="200" styleClass="status_pane_style"/>
-      <FlowPane fx:id="tags"/>
       <FlowPane fx:id="availableDays" prefWrapLength="300" styleClass="availability_pane_style" />
     </VBox>
   </GridPane>

--- a/src/main/resources/view/FocusListCard.fxml
+++ b/src/main/resources/view/FocusListCard.fxml
@@ -45,7 +45,7 @@
                             <Label fx:id="date" styleClass="focusStyle" />
                             <Label fx:id="time" styleClass="focusStyle" />
                         </HBox>
-                        <Label id="focus-card-label" fx:id="remark" styleClass="focusStyle" text="\$remark" />
+                        <Label id="focus-card-label" fx:id="remark" styleClass="focusStyle" text="\$remark" wrapText="true"/>
                     </VBox>
                 </GridPane>
             </VBox>

--- a/src/main/resources/view/FocusListCard.fxml
+++ b/src/main/resources/view/FocusListCard.fxml
@@ -10,37 +10,44 @@
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.text.Text?>
+<?import javafx.scene.layout.RowConstraints?>
+
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-        <ScrollPane id="focus-card-scroll-pane" VBox.vgrow="ALWAYS" minHeight="200" HBox.hgrow="ALWAYS" hbarPolicy="AS_NEEDED">
+        <ScrollPane id="focus-card-scroll-pane" VBox.vgrow="ALWAYS" minHeight="200" HBox.hgrow="ALWAYS" hbarPolicy="AS_NEEDED" fitToWidth="true">
             <VBox HBox.hgrow="ALWAYS">
-                <GridPane HBox.hgrow="ALWAYS" minWidth="300">
+                <GridPane HBox.hgrow="ALWAYS" minWidth="350">
                     <columnConstraints>
-                        <ColumnConstraints hgrow="SOMETIMES" minWidth="150" prefWidth="150" />
+                        <ColumnConstraints hgrow="SOMETIMES" minWidth="150" prefWidth="150" maxWidth="150"/>
+                        <ColumnConstraints hgrow="SOMETIMES" minWidth="200" prefWidth="200" />
                     </columnConstraints>
-                    <VBox alignment="CENTER" GridPane.columnIndex="0">
-                        <StackPane fx:id="stackPane" minHeight="150" minWidth="150" >
+                    <rowConstraints>
+                        <RowConstraints/>
+                        <RowConstraints />
+                    </rowConstraints>
+                    <VBox alignment="CENTER" GridPane.columnIndex="0" GridPane.rowIndex="0">
+                        <StackPane  fx:id="stackPane" alignment="CENTER" minHeight="150" minWidth="150" GridPane.hgrow="ALWAYS" GridPane.fillWidth="true" >
                             <Text fx:id="profileName" styleClass="profileTextStyle" />
                         </StackPane>
                     </VBox>
-                    <columnConstraints>
-                        <ColumnConstraints hgrow="SOMETIMES" minWidth="200" prefWidth="200" maxWidth="250"/>
-                    </columnConstraints>
-                    <VBox fx:id="keyAttributes" styleClass="keyAttributesVBox" alignment="CENTER_LEFT" minWidth="100" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS" GridPane.columnIndex="1">
+                    <VBox fx:id="keyAttributes" styleClass="keyAttributesVBox" alignment="CENTER_LEFT" minWidth="100" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS" GridPane.columnIndex="1"  GridPane.rowIndex="0">
                         <Label fx:id="name" styleClass="focusStyleName" text="\$phone" />
                         <Label fx:id="id" styleClass="focusStyleName" text="\$id" />
                         <FlowPane fx:id="statusFocusPane" prefWrapLength="200"/>
                         <FlowPane fx:id="availableDaysFocus" prefWrapLength="200"/>
                     </VBox>
+                    <VBox styleClass="keyAttributesVBox" alignment="CENTER_LEFT" minWidth="100" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS" GridPane.rowIndex="1" GridPane.columnSpan="2" >
+                        <Label id="focus-card-label" fx:id="phone" styleClass="focusStyle" text="\$phone" />
+                        <Label id="focus-card-label" fx:id="email" styleClass="focusStyle" text="\$email" />
+                        <Label id="focus-card-label" fx:id="course" styleClass="focusStyle" text="\$course" />
+                        <Label id="focus-card-schedule-label" fx:id="scheduleMessage" styleClass="focusStyle" />
+                        <HBox>
+                            <Label id="focus-card-label" fx:id="day" styleClass="focusStyle" />
+                            <Label fx:id="date" styleClass="focusStyle" />
+                            <Label fx:id="time" styleClass="focusStyle" />
+                        </HBox>
+                        <Label id="focus-card-schedule-label" styleClass="focusStyle" wrapText="true" text="placeholder for remark"/>
+                    </VBox>
                 </GridPane>
-                <Label id="focus-card-label" fx:id="phone" styleClass="focusStyle" text="\$phone" />
-                <Label id="focus-card-label" fx:id="email" styleClass="focusStyle" text="\$email" />
-                <Label id="focus-card-label" fx:id="course" styleClass="focusStyle" text="\$course" />
-                <Label id="focus-card-schedule-label" fx:id="scheduleMessage" styleClass="focusStyle" />
-                <HBox>
-                    <Label id="focus-card-label" fx:id="day" styleClass="focusStyle" />
-                    <Label fx:id="date" styleClass="focusStyle" />
-                    <Label fx:id="time" styleClass="focusStyle" />
-                </HBox>
             </VBox>
         </ScrollPane>
 </HBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -48,7 +48,7 @@
           </padding>
         </StackPane>
 
-        <SplitPane fx:id="splitPanePlaceholder" VBox.vgrow="ALWAYS" dividerPositions="0.35, 0.70">
+        <SplitPane fx:id="splitPanePlaceholder" VBox.vgrow="ALWAYS" dividerPositions="0.35, 0.75">
           <items>
             <VBox fx:id="candidateList" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
               <padding>

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -78,10 +78,10 @@ public class FindCommandParserTest {
         // no leading and trailing whitespaces
         FindCommand expectedFindStudentIdCommand =
                 new FindCommand(new StudentIdContainsKeywordsPredicate(Arrays.asList("E0324", "149")));
-        assertParseSuccess(parser, " k/E0324 k/149 f/id", expectedFindStudentIdCommand);
+        assertParseSuccess(parser, " k/E0324 k/149 f/studentid", expectedFindStudentIdCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, "    k/E0324 \t \t  k/149  \t  f/id \t", expectedFindStudentIdCommand);
+        assertParseSuccess(parser, "    k/E0324 \t \t  k/149  \t  f/studentid \t", expectedFindStudentIdCommand);
     }
 
     @Test
@@ -89,12 +89,12 @@ public class FindCommandParserTest {
         // no leading and trailing whitespaces
         FindCommand expectedFindInterviewStatusCommand =
                 new FindCommand(new InterviewStatusContainsKeywordsPredicate(Arrays.asList("pending", "reject")));
-        assertParseSuccess(parser, " k/pending k/reject f/is", expectedFindInterviewStatusCommand);
+        assertParseSuccess(parser, " k/pending k/reject f/intstatus", expectedFindInterviewStatusCommand);
 
         // multiple whitespaces between keywords
         FindCommand expectedFindApplicationStatusCommand =
                 new FindCommand(new ApplicationStatusContainsKeywordsPredicate(Arrays.asList("pending", "reject")));
-        assertParseSuccess(parser, " k/  pending    k/  reject   f/     as",
+        assertParseSuccess(parser, " k/  pending    k/  reject   f/     appstatus",
                 expectedFindApplicationStatusCommand);
     }
 
@@ -103,7 +103,7 @@ public class FindCommandParserTest {
         // no leading and trailing whitespaces
         FindCommand expectedFindSeniorityCommand =
                 new FindCommand(new SeniorityContainsKeywordsPredicate(Arrays.asList("2", "com1")));
-        assertParseSuccess(parser, " k/2 k/com1 f/yr", expectedFindSeniorityCommand);
+        assertParseSuccess(parser, " k/2 k/com1 f/seniority", expectedFindSeniorityCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -60,31 +60,27 @@ public class SortCommandParserTest {
 
         SortCommand expectedCommandName = new SortCommand(sortComparatorName, "name");
         SortCommand expectedCommandCourse = new SortCommand(sortComparatorCourse, "course");
-        SortCommand expectedCommandStudentId = new SortCommand(sortComparatorStudentId, "id");
-        SortCommand expectedCommandPhone = new SortCommand(sortComparatorPhone, "phone");
-        SortCommand expectedCommandEmail = new SortCommand(sortComparatorEmail, "email");
+        SortCommand expectedCommandStudentId = new SortCommand(sortComparatorStudentId, "studentid");
         SortCommand expectedCommandApplicationStatus = new SortCommand(sortComparatorApplicationStatus,
-                "as");
-        SortCommand expectedCommandInterviewStatus = new SortCommand(sortComparatorInterviewStatus, "is");
-        SortCommand expectedCommandSeniority = new SortCommand(sortComparatorSeniority, "yr");
+                "appstatus");
+        SortCommand expectedCommandInterviewStatus = new SortCommand(sortComparatorInterviewStatus, "intstatus");
+        SortCommand expectedCommandSeniority = new SortCommand(sortComparatorSeniority, "seniority");
 
         assertParseSuccess(parser, SORT_EMPTY + "name", expectedCommandName);
         assertParseSuccess(parser, " " + PREFIX_SORTKEY + "name", expectedCommandName);
         assertParseSuccess(parser, SORT_EMPTY + "course", expectedCommandCourse);
-        assertParseSuccess(parser, SORT_EMPTY + "id", expectedCommandStudentId);
-        assertParseSuccess(parser, SORT_EMPTY + "phone", expectedCommandPhone);
-        assertParseSuccess(parser, SORT_EMPTY + "email", expectedCommandEmail);
-        assertParseSuccess(parser, SORT_EMPTY + "as", expectedCommandApplicationStatus);
-        assertParseSuccess(parser, SORT_EMPTY + "is", expectedCommandInterviewStatus);
-        assertParseSuccess(parser, SORT_EMPTY + "yr", expectedCommandSeniority);
+        assertParseSuccess(parser, SORT_EMPTY + "studentid", expectedCommandStudentId);
+        assertParseSuccess(parser, SORT_EMPTY + "appstatus", expectedCommandApplicationStatus);
+        assertParseSuccess(parser, SORT_EMPTY + "intstatus", expectedCommandInterviewStatus);
+        assertParseSuccess(parser, SORT_EMPTY + "seniority", expectedCommandSeniority);
     }
 
     @Test
     public void parse_multipleRepeatedFields_acceptsLast() {
-        String userInput = SORT_EMPTY + "name" + SORT_EMPTY + "course" + SORT_EMPTY + "id";
+        String userInput = SORT_EMPTY + "name" + SORT_EMPTY + "course" + SORT_EMPTY + "studentid";
 
         Comparator<Candidate> sortComparator = Comparator.comparing(l -> l.getStudentId().toString().toLowerCase());
-        SortCommand expectedCommand = new SortCommand(sortComparator, "id");
+        SortCommand expectedCommand = new SortCommand(sortComparator, "studentid");
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }


### PR DESCRIPTION
This PR includes:

1. edits to the UI to make it smoother, fixes the expansion in the middle panel
2. added back `course` and `seniority` to candidate cards after some discussion w dom - TDLR: felt that as a user, might want to be able to view the course and seniority of candidates easily on the left panel to preliminarily decide the priority of scheduling interviews for these candidates.
3. standardises the prefixes used for `sort` and `find` command - TLDR: was on the fence between using the prefixes for the `add` command as the `ATTRIBUTE_FIELD` values for the `sort` and `find` commands. But after consideration, decided to instead shorten `applicationstatus` to `appstatus` and `interviewstatus` to `intstatus`, while leaving the rest of the fields typed out in full. This is to make it easier for the user to intuitively type which field they would like to sort/find by (sorry still a bit of a long explanation).
4. adds `remark` to the UG

Closes #252 