### PR TITLE
Issues #263: Fix refresh on `view` when `remark` and `edit`

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -173,18 +173,17 @@ Format: `list`
 
 Finds and lists candidates whose attribute field(s) contain(s) any of the given keyword(s).
 
-Format: `find k/KEYWORD [k/MORE_KEYWORDS]... f/ATTRIBUTE_FIELD`
+Format: `find k/KEYWORD [k/MORE_KEYWORDS]... [f/ATTRIBUTE_FIELD]`
 
 <div markdown="block" class="alert alert-info">
 
 **:information_source: Notes about the find format:**<br>
 
-`ATTRIBUTE_FIELD` can take on the following values 
-`appstatus`, `course`, `email`, `intstatus`, `name`, `phone`, `seniority`, `studentid`, `all`, `avail`
+`ATTRIBUTE_FIELD` can take on the following values
+`all`, `avail`, `appstatus`, `course`, `email`, `intstatus`, `name`, `phone`, `seniority`, `studentid`, `remark`
 
-Note: 
-`seniority` may match any case variation of `COM1`, `COM2`, `COM3` or `COM4`
-`avail` may match any case variation of days in the format of `MON`, `TUE`, `WED`, `THUR` or `FRI`
+* A candidate's`seniority` may match any case variation of `COM1`, `COM2`, `COM3` or `COM4`
+* A candidate's `avail` may match any case variation of days in the format of `MON`, `TUE`, `WED`, `THUR` or `FRI`
 
 </div>
 
@@ -201,7 +200,7 @@ Note:
 
 Examples:
 * `find k/Jane f/name` returns candidates with name e.g. `jane` and `jane doe`
-* `find k/Computer Science f/course` returns candidates with the course field i.e. `computer science`
+* `find k/Computer k/Science f/course` returns candidates with the course field i.e. `computer science` and `computer engineering`
 * `find k/Jane k/Tan f/name` returns candidates with name e.g. `Jane`, `tan` and `John Tan`
 
 ### Sorting candidates by attribute field: `sort`
@@ -240,11 +239,11 @@ Let's reference a default sample list of unique candidates with attribute fields
 3. (`Ben`, `A5588565L`)
 
 
-### Updating a candidate's remarks: `remark`
+### Updating a candidate's remark: `remark`
 
 Updates the `remark` field of a candidate to the user input keyed in.
 
-Format: `remark INDEX r/REMARK`
+Format: `remark INDEX [r/REMARK]`
 
 <div markdown="block" class="alert alert-info">
 
@@ -254,12 +253,12 @@ Format: `remark INDEX r/REMARK`
 
 </div>
 
-* To remove the remark of the first candidate displayed in the system, the user can simply key in `remark 1 r/`, 
+* To remove the remark of the first candidate displayed in the system, the user can simply key in `remark 1` or `remark 1 r/`, 
 which will update the remark of the candidate to be empty.
 
 Examples:
 * `remark 1 r/a good candidate` Updates the candidate's remark field to reflect 'a good candidate'.
-* `remark 1 r/` Removes the candidate's remark field to reflect ''.
+* `remark 1 r/` Removes the candidate's remark field to reflect ``.
 
 ### Deleting a candidate : `delete`
 
@@ -293,7 +292,7 @@ Schedules the specified candidate for an interview.
 
 Format: `schedule add candidate/INDEX at/DATE_TIME`
 
-* Schedules the candidate at the specified `INDEX` for an interview on given `DATE_TIME`.
+* Schedules the candidate at the specified `INDEX` for an interview on given `DATE_TIME`
 * The candidate index refers to the index number shown in the displayed candidate list.
 * The candidate index must be a positive integer 1, 2, 3, …​
 * `DATE_TIME` must be specified in the format `dd-MM-yyyy HH:mm`.
@@ -350,13 +349,10 @@ Format: `view TIME_PERIOD`
 * Scheduled interviews are automatically sorted from earliest to latest
 
 Examples:
-
-| Example command | Expected Behaviour                                                               |
-|-----------------|----------------------------------------------------------------------------------|
-| `view all`      | returns all scheduled interviews still in system whether in the past or upcoming |
-| `view today`    | returns all scheduled interviews on the same date as the current time            |
-| `view week`     | returns all upcoming scheduled interviews within the next 7 days                 |
-| `view month`    | returns all upcoming scheduled interviews within the next month                  |
+* `view all` returns all scheduled interviews still in system whether in the past or upcoming
+* `view today` returns all scheduled interviews on the same date as the current time
+* `view week` returns all upcoming scheduled interviews within the next 7 days
+* `view month` returns all upcoming scheduled interviews within the next month
 
 ## Miscellaneous commands
 
@@ -403,20 +399,16 @@ If your changes to the data file makes its format invalid, TAlent Assistant™ w
 
 Commands in this section have been organised based on the expected scope of behaviour.
 
-### Candidates List
+### Managing Candidates
 | Action     | Format, Examples                                                                                                                                                                               |
 |------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Add**    | `add id/STUDENTID n/NAME e/EMAIL p/PHONE c/COURSE yr/SENIORITY avail/AVAILABILITY`<br> e.g., `add id/A0123456B n/John Doe p/87654321 e/E0123456@u.nus.edu c/Computer Science yr/2 avail/1,2,3` |
 | **Delete** | `delete INDEX`<br> e.g., `delete 3`                                                                                                                                                            |
 | **Edit**   | `edit INDEX [n/NAME] [e/EMAIL] [p/PHONE_NUMBER] [c/COURSE] [yr/YEAR] [avail/AVAILABILITY] [as/APPLICATION_STATUS]…​`<br> e.g.,`edit 2 n/James Lee p/98765432 yr/4`                             |
-| **Find**   | `find k/KEYWORD [k/MORE_KEYWORDS]... f/ATTRIBUTE_FIELD`<br> e.g., `find k/Jane k/Doe f/name`                                                                                                   |
+| **Find**   | `find k/KEYWORD [k/MORE_KEYWORDS]... [f/ATTRIBUTE_FIELD]`<br> e.g., `find k/Jane k/Doe f/name`                                                                                                 |
 | **Sort**   | `sort s/ATTRIBUTE_FIELD`<br> e.g., `sort s/name`                                                                                                                                               |
-| **Remark** | `remark INDEX r/REMARKS`<br> e.g., `remark 1 r/a good candidate`                                                                                                                               |
-
-### Candidate Profile
-| Action    | Format, Examples |
-|-----------|------------------|
-| **Focus** | [[PLACEHOLDER]]  |
+| **Remark** | `remark INDEX [r/REMARK]`<br> e.g., `remark 1 r/a good candidate`                                                                                                                              |
+| **Focus**  | [[PLACEHOLDER]]                                                                                                                                                                                |
 
 ### Scheduling Interviews
 | Action                        | Format, Examples                                                                                       |
@@ -424,6 +416,7 @@ Commands in this section have been organised based on the expected scope of beha
 | **Schedule interview**        | `schedule add candidate/INDEX /at DATE_TIME` <br> e.g., `schedule add candidate/2 at/05-05-2022 10:00` |
 | **Reschedule interview**      | `schedule edit SCHEDULE_INDEX at/DATE_TIME` <br> e.g., `schedule edit 1 at/06-06-2022 15:00`           |
 | **Delete interview**          | `schedule delete SCHEDULE_INDEX` <br> e.g., `schedule delete 1`                                        |
+| **Clear all interviews**      | [[PLACEHOLDER]]                                                                                        |
 | **View scheduled interviews** | `view TIME_PERIOD` <br> e.g., `view all`, `view today`                                                 |
 
 ### Miscellaneous commands / Help

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -292,7 +292,7 @@ Schedules the specified candidate for an interview.
 
 Format: `schedule add candidate/INDEX at/DATE_TIME`
 
-* Schedules the candidate at the specified `INDEX` for an interview on given `DATE_TIME`
+* Schedules the candidate at the specified `INDEX` for an interview on given `DATE_TIME`.
 * The candidate index refers to the index number shown in the displayed candidate list.
 * The candidate index must be a positive integer 1, 2, 3, …​
 * `DATE_TIME` must be specified in the format `dd-MM-yyyy HH:mm`.

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -183,7 +183,7 @@ public class MainApp extends Application {
 
     @Override
     public void start(Stage primaryStage) {
-        logger.info("Starting AddressBook " + MainApp.VERSION);
+        logger.info("Starting TalentAssistant " + MainApp.VERSION);
         model.deletePastInterviewsForInterviewList(LocalDateTime.now());
         ui.start(primaryStage);
     }

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -10,6 +10,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_CANDIDATE_DISPLAYED_INDEX = "The candidate index provided is invalid";
     public static final String MESSAGE_NO_CANDIDATES_IN_SYSTEM = "There are no candidates in the system!";
     public static final String MESSAGE_CANDIDATES_LISTED_OVERVIEW = "%1$d candidates listed!";
+    public static final String MESSAGE_CANDIDATES_SORTED_OVERVIEW = "%1$d candidates sorted!";
     public static final String MESSAGE_INTERVIEWS_LISTED_OVERVIEW = "%1$d interviews listed!";
     public static final String MESSAGE_INVALID_INTERVIEW_DISPLAYED_INDEX = "The interview index provided is invalid";
     public static final String MESSAGE_NO_INTERVIEWS_IN_SYSTEM = "There are no interviews scheduled!";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -9,7 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SENIORITY;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CANDIDATES;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -10,7 +10,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SENIORITY;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CANDIDATES;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_INTERVIEWS;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -107,7 +107,6 @@ public class EditCommand extends Command {
                 model.updateInterviewCandidate(interviewToUpdate, updatedInterview);
             }
         }
-        model.updateFilteredInterviewSchedule(PREDICATE_SHOW_ALL_INTERVIEWS);
 
         return new CommandResult(String.format(MESSAGE_EDIT_CANDIDATE_SUCCESS, editedCandidate));
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -99,7 +99,6 @@ public class EditCommand extends Command {
         }
 
         model.setCandidate(candidateToEdit, editedCandidate);
-        model.updateFilteredCandidateList(PREDICATE_SHOW_ALL_CANDIDATES);
 
         for (int i = 0; i < interviewSchedule.size(); i++) {
             if (candidateToEdit.equals(interviewSchedule.get(i).getCandidate())) {

--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -2,8 +2,6 @@ package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CANDIDATES;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_INTERVIEWS;
 
 import java.util.List;
 

--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -70,7 +70,6 @@ public class RemarkCommand extends Command {
                 remark);
 
         model.setCandidate(candidateToEdit, editedCandidate);
-        model.updateFilteredCandidateList(PREDICATE_SHOW_ALL_CANDIDATES);
 
         for (int i = 0; i < interviewSchedule.size(); i++) {
             if (candidateToEdit.equals(interviewSchedule.get(i).getCandidate())) {
@@ -79,7 +78,6 @@ public class RemarkCommand extends Command {
                 model.updateInterviewCandidate(interviewToUpdate, updatedInterview);
             }
         }
-        model.updateFilteredInterviewSchedule(PREDICATE_SHOW_ALL_INTERVIEWS);
 
         return new CommandResult(generateSuccessMessage(editedCandidate));
     }

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -17,14 +17,12 @@ public class SortCommand extends Command {
 
     public static final String COMMAND_WORD = "sort";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts all candidates by the field specified "
-            + "in ascending order (A-Z, 0-9) and displays them as a list with index numbers.\n"
-            + " The search can be conducted only on a specific field in candidates' description by specifying the"
-            + PREFIX_SORTKEY + " SORTKEY argument.\n"
-            + "Parameters: " + PREFIX_SORTKEY + "SORTKEY \n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts all currently displayed candidates "
+            + "by the field specified in ascending order (A-Z, 0-9).\n"
+            + "Parameters: " + PREFIX_SORTKEY + "ATTRIBUTE_FIELD \n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_SORTKEY + "name\n"
-            + "Allowable fields to be sorted by include: appstatus, course, "
-            + "intstatus, name, seniority, studentid.";
+            + "Note: Allowable fields for sorting include `appstatus`, `course`, "
+            + "`intstatus`, `name`, `seniority`, `studentid`.";
 
     private final Comparator<Candidate> sortComparator;
     private final String sortKey;
@@ -48,7 +46,7 @@ public class SortCommand extends Command {
         requireNonNull(model);
         model.updateSortedCandidateList(sortComparator);
         return new CommandResult(
-                String.format(Messages.MESSAGE_CANDIDATES_LISTED_OVERVIEW, model.getFilteredCandidateList().size()));
+                String.format(Messages.MESSAGE_CANDIDATES_SORTED_OVERVIEW, model.getFilteredCandidateList().size()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -3,7 +3,9 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.interview.predicate.AllWithinTimePeriodPredicate;
 import seedu.address.model.interview.predicate.WithinTimePeriodPredicate;
 
 /**
@@ -20,8 +22,6 @@ public class ViewCommand extends Command {
             + "Note: Allowable time periods include `all` (i.e. all scheduled interviews in the system),"
             + " `today` (i.e. same day), `week` (i.e. next 7 days), month (i.e. period till the next month).";
 
-    public static final String MESSAGE_NO_INTERVIEWS_IN_SYSTEM = "No interviews scheduled yet!";
-
     private final WithinTimePeriodPredicate predicate;
 
     public ViewCommand(WithinTimePeriodPredicate predicate) {
@@ -30,8 +30,13 @@ public class ViewCommand extends Command {
 
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        if (predicate instanceof AllWithinTimePeriodPredicate && model.getInterviewSchedule().getInterviewList().size() == 0) {
+            throw new CommandException(String.format(Messages.MESSAGE_NO_INTERVIEWS_IN_SYSTEM));
+        }
+
         model.updateFilteredInterviewSchedule(predicate);
         return new CommandResult(String
                 .format(Messages.MESSAGE_INTERVIEWS_LISTED_OVERVIEW, model.getFilteredInterviewSchedule().size()));

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -33,7 +33,7 @@ public class ViewCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (predicate instanceof AllWithinTimePeriodPredicate 
+        if (predicate instanceof AllWithinTimePeriodPredicate
                 && model.getInterviewSchedule().getInterviewList().size() == 0) {
             throw new CommandException(String.format(Messages.MESSAGE_NO_INTERVIEWS_IN_SYSTEM));
         }

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -33,7 +33,8 @@ public class ViewCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (predicate instanceof AllWithinTimePeriodPredicate && model.getInterviewSchedule().getInterviewList().size() == 0) {
+        if (predicate instanceof AllWithinTimePeriodPredicate 
+                && model.getInterviewSchedule().getInterviewList().size() == 0) {
             throw new CommandException(String.format(Messages.MESSAGE_NO_INTERVIEWS_IN_SYSTEM));
         }
 

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -13,12 +13,12 @@ public class ViewCommand extends Command {
 
     public static final String COMMAND_WORD = "view";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": View all scheduled interviews "
-            + " scheduled within a specific time period.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": View all scheduled interviews in the system"
+            + " scheduled within a specified time period.\n"
             + "Parameters: TIME_PERIOD\n"
             + "Example: " + COMMAND_WORD + " today\n"
-            + "Allowable time periods include today (i.e. the same day), week (i.e. this week), "
-            + "month (i.e. this month)";
+            + "Note: Allowable time periods include `all` (i.e. all scheduled interviews in the system),"
+            + " `today` (i.e. same day), `week` (i.e. next 7 days), month (i.e. period till the next month).";
 
     public static final String MESSAGE_NO_INTERVIEWS_IN_SYSTEM = "No interviews scheduled yet!";
 

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -24,7 +24,7 @@ public class SortCommandParser implements Parser<SortCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_SORTKEY);
 
-        // throws exception if no sort key is specified
+        // throws exception if no sort attribute field is specified
         if (!arePrefixesPresent(argMultimap, PREFIX_SORTKEY)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/ui/FocusCard.java
+++ b/src/main/java/seedu/address/ui/FocusCard.java
@@ -210,8 +210,8 @@ public class FocusCard extends UiPart<Region> {
             initials.append(temp[0].charAt(0));
         }
 
-        stackPane.setStyle(CHANGE_COLOUR + COLORS[26]);
-
+        stackPane.setStyle(CHANGE_COLOUR + COLORS[temp[0].charAt(0) - OFFSET]);        
+        
         Circle circle = new Circle();
         circle.setRadius(60);
         circle.setCenterX(75);

--- a/src/main/java/seedu/address/ui/FocusCard.java
+++ b/src/main/java/seedu/address/ui/FocusCard.java
@@ -210,8 +210,8 @@ public class FocusCard extends UiPart<Region> {
             initials.append(temp[0].charAt(0));
         }
 
-        stackPane.setStyle(CHANGE_COLOUR + COLORS[temp[0].charAt(0) - OFFSET]);        
-        
+        stackPane.setStyle(CHANGE_COLOUR + COLORS[temp[0].charAt(0) - OFFSET]);
+
         Circle circle = new Circle();
         circle.setRadius(60);
         circle.setCenterX(75);

--- a/src/main/java/seedu/address/ui/FocusCard.java
+++ b/src/main/java/seedu/address/ui/FocusCard.java
@@ -210,7 +210,7 @@ public class FocusCard extends UiPart<Region> {
             initials.append(temp[0].charAt(0));
         }
 
-        stackPane.setStyle(CHANGE_COLOUR + COLORS[temp[0].charAt(0) - OFFSET]);
+        stackPane.setStyle(CHANGE_COLOUR + COLORS[26]);
 
         Circle circle = new Circle();
         circle.setRadius(60);

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -5,5 +5,5 @@
 
 <StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/8"
     xmlns:fx="http://javafx.com/fxml/1">
-  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
+  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" wrapText="true"/>
 </StackPane>

--- a/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalCandidates.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalInterviews.getTypicalInterviewSchedule;
 
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.InterviewSchedule;
 import seedu.address.model.Model;
@@ -46,8 +48,6 @@ public class ViewCommandTest {
     public void execute_listIsEmpty_showsNoInterviewsListed() {
         model = new ModelManager(new AddressBook(), new InterviewSchedule(), new UserPrefs());
         expectedModel = new ModelManager(model.getAddressBook(), model.getInterviewSchedule(), new UserPrefs());
-        assertCommandSuccess(new ViewCommand(predicate), model, new CommandResult(String
-                .format(Messages.MESSAGE_INTERVIEWS_LISTED_OVERVIEW, model.getFilteredInterviewSchedule().size())),
-                expectedModel);
+        assertThrows(CommandException.class, () -> new ViewCommand(predicate).execute(model));
     }
 }


### PR DESCRIPTION
Includes 

1. temporary fix to profile photo colour as the bug disallows me from loading up any profiles ( @LeeEnEn see issue tagged in the bug thread)
2. slight updates to documentation of UG
3. allow wrapping of result display box

@lzan98 appreciate your help to confirm that the deletion of the lines from `RemarkCommand` and `EditCommand` doesnt affect any behaviour from testings that you have done? - as from my understanding the setCandidate() method should not update the indexes of the candidates etc.

Closes #264 