### PR TITLE
Add refresh method for `ScheduleClear`

### DIFF
--- a/src/main/java/seedu/address/logic/commands/schedule/ClearScheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/schedule/ClearScheduleCommand.java
@@ -23,7 +23,7 @@ public class ClearScheduleCommand extends ScheduleCommand {
         requireNonNull(model);
         List<Candidate> candidatesToSetComplete = model.getExpiredInterviewCandidates();
         for (Candidate c : candidatesToSetComplete) {
-            model.setCandidate(c, c.setCompleted());
+            model.setCandidate(c, c.triggerInterviewStatusCompleted());
         }
         model.setInterviewSchedule(new InterviewSchedule());
         model.resetAllScheduledStatus();

--- a/src/main/java/seedu/address/model/candidate/Candidate.java
+++ b/src/main/java/seedu/address/model/candidate/Candidate.java
@@ -244,35 +244,4 @@ public class Candidate {
         return interviewStatus.equals(new InterviewStatus(SCHEDULED));
     }
 
-    public Candidate setNotScheduled() {
-        requireAllNonNull(name, phone, email, course, seniority,
-                applicationStatus, interviewStatus, availability);
-        return new Candidate(this.getStudentId(),
-                this.getName(),
-                this.getPhone(),
-                this.getEmail(),
-                this.getCourse(),
-                this.getSeniority(),
-                this.getApplicationStatus(),
-                new InterviewStatus(NOT_SCHEDULED),
-                this.getAvailability(),
-                this.getRemark()
-        );
-    }
-
-    public Candidate setCompleted() {
-        requireAllNonNull(name, phone, email, course, seniority,
-                applicationStatus, interviewStatus, availability);
-        return new Candidate(this.getStudentId(),
-                this.getName(),
-                this.getPhone(),
-                this.getEmail(),
-                this.getCourse(),
-                this.getSeniority(),
-                this.getApplicationStatus(),
-                new InterviewStatus(COMPLETED),
-                this.getAvailability(),
-                this.getRemark()
-        );
-    }
 }

--- a/src/main/java/seedu/address/model/candidate/UniqueCandidateList.java
+++ b/src/main/java/seedu/address/model/candidate/UniqueCandidateList.java
@@ -142,7 +142,7 @@ public class UniqueCandidateList implements Iterable<Candidate> {
     public void resetScheduledStatus() {
         for (Candidate c : internalList) {
             if (c.isScheduled()) {
-                setCandidate(c, c.setNotScheduled());
+                setCandidate(c, c.triggerInterviewStatusNotScheduled());
             }
         }
     }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -20,6 +20,7 @@ import seedu.address.logic.commands.FocusCommand;
 import seedu.address.logic.commands.RemarkCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.schedule.AddScheduleCommand;
+import seedu.address.logic.commands.schedule.ClearScheduleCommand;
 import seedu.address.logic.commands.schedule.DeleteScheduleCommand;
 import seedu.address.logic.commands.schedule.EditScheduleCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -271,11 +272,27 @@ public class MainWindow extends UiPart<Stage> {
     public CommandResult executeCommandThenRefresh(String commandText) throws CommandException, ParseException {
         CommandResult commandResult = logic.execute(commandText);
         resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
-        if (focusListPanel.getCandidate().looseEqual(logic
-                .getFilteredCandidateList()
-                .get(commandResult.getEditIndex()))) {
+        if (!focusListPanelPlaceholder.getChildren().isEmpty()) {
+            if (focusListPanel.getCandidate().looseEqual(logic
+                    .getFilteredCandidateList()
+                    .get(commandResult.getEditIndex()))) {
+                executeCommand(FocusCommand.COMMAND_WORD + " "
+                        + String.valueOf(commandResult.getEditIndex() + 1));
+            }
+        }
+        return commandResult;
+    }
+
+    /**
+     * Refreshes the FocusCard if all schedules are cleared so that the displayed Candidate has the latest information.
+     */
+    public CommandResult refreshWhenClearAllSchedule(String commandText) throws CommandException, ParseException {
+        int displayedIndex = logic.getFilteredCandidateList().indexOf(focusListPanel.getCandidate());
+        CommandResult commandResult = logic.execute(commandText);
+        if (!focusListPanelPlaceholder.getChildren().isEmpty()) {
+            logger.info(String.valueOf(logic.getFilteredCandidateList().contains(focusListPanel.getCandidate())));
             executeCommand(FocusCommand.COMMAND_WORD + " "
-                    + String.valueOf(commandResult.getEditIndex() + 1));
+                    + String.valueOf(displayedIndex + 1));
         }
         return commandResult;
     }
@@ -289,11 +306,9 @@ public class MainWindow extends UiPart<Stage> {
         try {
             int editFlag = -1;
 
-            if (commandText.contains(DeleteScheduleCommand.COMMAND_WORD)) {
-                return executeCommandThenRefresh(commandText);
-            } else if (commandText.contains(RemarkCommand.COMMAND_WORD)) {
-                return executeCommandThenRefresh(commandText);
-            } else if (commandText.contains(EditScheduleCommand.COMMAND_WORD)) {
+            if (commandText.contains(DeleteScheduleCommand.COMMAND_WORD)
+                    || commandText.contains(RemarkCommand.COMMAND_WORD)
+                    || (commandText.contains(EditScheduleCommand.COMMAND_WORD))) {
                 return executeCommandThenRefresh(commandText);
             } else if (commandText.contains(DeleteCommand.COMMAND_WORD)) {
                 handleDelete(commandText);
@@ -301,6 +316,8 @@ public class MainWindow extends UiPart<Stage> {
                 editFlag = handleEdit(commandText, EDIT_COMMAND_INDEX);
             } else if (commandText.contains(AddScheduleCommand.COMMAND_WORD)) {
                 editFlag = handleEdit(commandText, ADD_SCHEDULE_COMMAND_INDEX);
+            } else if (commandText.contains(ClearScheduleCommand.COMMAND_WORD)) {
+                return refreshWhenClearAllSchedule(commandText);
             }
 
             CommandResult commandResult = logic.execute(commandText);


### PR DESCRIPTION
Created the method to refresh the `FocusCard` when user clears all schedule.
@lzan98 I also removed the 2 methods called `setCompleted` and `setNotScheduled` in `Candidate` as there is a similar function used in the `Candidate` class ! Hope I didn't break anything. 

closes #267 