### PR TITLE
Update help window

### DIFF
--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -30,8 +30,9 @@ public class HelpWindow extends UiPart<Stage> {
     private static final String REMARK_FIELD = INDEX + " r/REMARKS";
     private static final String SCHEDULE_INDEX = "SCHEDULE_INDEX";
     private static final String SCHEDULE_FIELD = "add candidate/" + INDEX + " at/dd-MM-yyyy HH:mm\n"
-            + "delete " + SCHEDULE_INDEX
-            + "\nedit " + SCHEDULE_INDEX + " at/dd-MM-yyyy HH:mm";
+            + "edit " + SCHEDULE_INDEX + " at/dd-MM-yyyy HH:mm"
+            + "\ndelete " + SCHEDULE_INDEX
+            + "\nclear";
     private static final String SORT_FIELD = "s/ATTRIBUTE_FIELD";
     private static final String VIEW_FIELD = "today | week | month | all";
 

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -22,10 +22,10 @@ public class HelpWindow extends UiPart<Stage> {
             + "avail/AVAILABILITY";
     private static final String CLEAR_FIELD = "Clears Candidate and Interview lists";
     private static final String INDEX = "INDEX";
-    private static final String EDIT_FIELD = INDEX + " PREFIX/NEW VALUE";
+    private static final String EDIT_FIELD = INDEX + " PREFIX/NEW_VALUE";
     private static final String EXIT_FIELD = "Ends the program";
-    private static final String FIND_FIELD = "k/KEYWORD [k/MORE_KEYWORDS] [f/ATTRIBUTE_FIELD]";
-    private static final String LIST_FIELD = "List all candidates in the system";
+    private static final String FIND_FIELD = "k/KEYWORD [k/MORE_KEYWORDS]... [f/ATTRIBUTE_FIELD]";
+    private static final String LIST_FIELD = "Lists all candidates in the system";
     private static final String HELP_FIELD = "Opens the help window";
     private static final String REMARK_FIELD = INDEX + " r/REMARKS";
     private static final String SCHEDULE_INDEX = "SCHEDULE_INDEX";

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -18,13 +18,22 @@ public class HelpWindow extends UiPart<Stage> {
     public static final String USERGUIDE_URL =
             "https://ay2122s2-cs2103-f11-2.github.io/tp/UserGuide.html";
     private static final String HELP_MESSAGE = "Available commands on this version";
-    private static final String ADD_FIELD = "n/NAME id/STUDENT_ID c/COURSE avail/AVAILABILITY";
-    private static final String FIELD_IS_INDEX = "INDEX";
-    private static final String EDIT_FIELD = FIELD_IS_INDEX + " [PREFIX]/[NEW VALUE]";
-    private static final String FIND_FIELD = "k/KEYWORD k/[MORE_KEYWORDS] f/[ATTRIBUTE_FIELD]";
-    private static final String SCHEDULE_FIELD = "add candidate/" + FIELD_IS_INDEX + " at/dd-MM-yyyy HH:mm";
-    private static final String SORT_FIELD = "s/ATTRIBUTE";
-    private static final String VIEW_FIELD = "[today] [week] [month]";
+    private static final String ADD_FIELD = "id/STUDENT_ID n/NAME e/EMAIL p/PHONE c/COURSE yr/SENIORITY "
+            + "avail/AVAILABILITY";
+    private static final String CLEAR_FIELD = "Clears Candidate and Interview lists";
+    private static final String INDEX = "INDEX";
+    private static final String EDIT_FIELD = INDEX + " PREFIX/NEW VALUE";
+    private static final String EXIT_FIELD = "Ends the program";
+    private static final String FIND_FIELD = "k/KEYWORD [k/MORE_KEYWORDS] [f/ATTRIBUTE_FIELD]";
+    private static final String LIST_FIELD = "List all candidates in the system";
+    private static final String HELP_FIELD = "Opens the help window";
+    private static final String REMARK_FIELD = INDEX + " r/REMARKS";
+    private static final String SCHEDULE_INDEX = "SCHEDULE_INDEX";
+    private static final String SCHEDULE_FIELD = "add candidate/" + INDEX + " at/dd-MM-yyyy HH:mm\n"
+            + "delete " + SCHEDULE_INDEX
+            + "\nedit " + SCHEDULE_INDEX + " at/dd-MM-yyyy HH:mm";
+    private static final String SORT_FIELD = "s/ATTRIBUTE_FIELD";
+    private static final String VIEW_FIELD = "today | week | month | all";
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
@@ -33,19 +42,26 @@ public class HelpWindow extends UiPart<Stage> {
     private Button copyButton;
     @FXML
     private Label helpMessage;
-
     @FXML
     private Label addField;
+    @FXML
+    private Label clearField;
     @FXML
     private Label deleteField;
     @FXML
     private Label editField;
     @FXML
-    private Label exit;
+    private Label exitField;
     @FXML
     private Label findField;
     @FXML
     private Label focusField;
+    @FXML
+    private Label helpField;
+    @FXML
+    private Label listField;
+    @FXML
+    private Label remarkField;
     @FXML
     private Label scheduleField;
     @FXML
@@ -62,12 +78,17 @@ public class HelpWindow extends UiPart<Stage> {
         super(FXML, root);
         helpMessage.setText(HELP_MESSAGE);
         addField.setText(ADD_FIELD);
-        deleteField.setText(FIELD_IS_INDEX);
+        clearField.setText(CLEAR_FIELD);
+        deleteField.setText(INDEX);
         editField.setText(EDIT_FIELD);
+        exitField.setText(EXIT_FIELD);
         findField.setText(FIND_FIELD);
+        focusField.setText(INDEX);
+        helpField.setText(HELP_FIELD);
+        listField.setText(LIST_FIELD);
+        remarkField.setText(REMARK_FIELD);
         scheduleField.setText(SCHEDULE_FIELD);
         sortField.setText(SORT_FIELD);
-        focusField.setText(FIELD_IS_INDEX);
         viewField.setText(VIEW_FIELD);
     }
 

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -20,7 +20,7 @@ public class HelpWindow extends UiPart<Stage> {
     private static final String HELP_MESSAGE = "Available commands on this version";
     private static final String ADD_FIELD = "id/STUDENT_ID n/NAME e/EMAIL p/PHONE c/COURSE yr/SENIORITY "
             + "avail/AVAILABILITY";
-    private static final String CLEAR_FIELD = "Clears Candidate and Interview lists";
+    private static final String CLEAR_FIELD = "Clears all data in the system";
     private static final String INDEX = "INDEX";
     private static final String EDIT_FIELD = INDEX + " PREFIX/NEW_VALUE";
     private static final String EXIT_FIELD = "Ends the program";

--- a/src/main/resources/view/HelpWindow.css
+++ b/src/main/resources/view/HelpWindow.css
@@ -37,6 +37,7 @@
     -fx-background-radius: 3;
     -fx-font-size: 14;
     -fx-padding: 3 5 3 5;
+    -fx-font-family: "Segoe UI Semibold";
 }
 
 .styleHBox {

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -47,8 +47,8 @@
                 <Label fx:id="remarkField" styleClass="styleField"/>
             </HBox>
             <HBox styleClass="styleHBox">
-                <VBox minHeight="65" alignment="CENTER">
-                    <Label fx:id="scheduleCommand" styleClass="styleCommand" text="schedule" prefHeight="65"
+                <VBox minHeight="72" alignment="CENTER">
+                    <Label fx:id="scheduleCommand" styleClass="styleCommand" text="schedule" prefHeight="72"
                            prefWidth="70" alignment="CENTER"/>
                 </VBox>
                 <Label fx:id="scheduleField" styleClass="styleField"/>

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -43,7 +43,14 @@
                 <Label fx:id="focusField" styleClass="styleField"/>
             </HBox>
             <HBox styleClass="styleHBox">
-                <Label fx:id="scheduleCommand" styleClass="styleCommand" text="schedule" prefWidth="70" alignment="CENTER"/>
+                <Label fx:id="remarkCommand" styleClass="styleCommand" text="remark" prefWidth="70" alignment="CENTER" />
+                <Label fx:id="remarkField" styleClass="styleField"/>
+            </HBox>
+            <HBox styleClass="styleHBox">
+                <VBox minHeight="65" alignment="CENTER">
+                    <Label fx:id="scheduleCommand" styleClass="styleCommand" text="schedule" prefHeight="65"
+                           prefWidth="70" alignment="CENTER"/>
+                </VBox>
                 <Label fx:id="scheduleField" styleClass="styleField"/>
             </HBox>
             <HBox styleClass="styleHBox">
@@ -55,7 +62,20 @@
                 <Label fx:id="viewField" styleClass="styleField"/>
             </HBox>
             <HBox styleClass="styleHBox">
+                <Label fx:id="clear" styleClass="styleCommand" text="clear" prefWidth="70" alignment="CENTER" />
+                <Label fx:id="clearField" styleClass="styleField"/>
+            </HBox>
+            <HBox styleClass="styleHBox">
+                <Label fx:id="help" styleClass="styleCommand" text="help" prefWidth="70" alignment="CENTER" />
+                <Label fx:id="helpField" styleClass="styleField"/>
+            </HBox>
+            <HBox styleClass="styleHBox">
+                <Label fx:id="listCommand" styleClass="styleCommand" text="list" prefWidth="70" alignment="CENTER" />
+                <Label fx:id="listField" styleClass="styleField"/>
+            </HBox>
+            <HBox styleClass="styleHBox">
                 <Label fx:id="exit" styleClass="styleCommand" text="exit" prefWidth="70" alignment="CENTER" />
+                <Label fx:id="exitField" styleClass="styleField"/>
             </HBox>
         </children>
         <HBox fx:id="copyButtonHBox" alignment="BASELINE_RIGHT">

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -47,8 +47,8 @@
                 <Label fx:id="remarkField" styleClass="styleField"/>
             </HBox>
             <HBox styleClass="styleHBox">
-                <VBox minHeight="72" alignment="CENTER">
-                    <Label fx:id="scheduleCommand" styleClass="styleCommand" text="schedule" prefHeight="72"
+                <VBox minHeight="82" alignment="CENTER">
+                    <Label fx:id="scheduleCommand" styleClass="styleCommand" text="schedule" prefHeight="82"
                            prefWidth="70" alignment="CENTER"/>
                 </VBox>
                 <Label fx:id="scheduleField" styleClass="styleField"/>


### PR DESCRIPTION
Update help window to include missing commands:
- help
- list
- schedule edit
- schedule delete
- clear
- remark

Changed `INDEX` to `SCHEDULE_INDEX` for schedule edit and delete

Edit: Added schedule clear
Edit2: Changed `clear` from `Clears Candidate and Interview lists` to `Clears all data in the system`, enlarged command box to be inline with the last sub-command.

![image](https://user-images.githubusercontent.com/77260893/161063433-7b1e69f4-bd16-4e09-955b-56d3fd44c1b1.png)

Closes #279 