### PR TITLE
Issue #324: Add restriction on `course` entity in UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -110,6 +110,11 @@ Features relating to the display of information within these panels are describe
 | `yr`                | seniority          |
 | `avail`             | availability       |
 
+**:information_source: Notes about the entities' values:**<br>
+
+* A candidate's `course` can only be either of the 5 computing courses in NUS School of Computing i.e. Business Analytics, Computer Engineering, Computer Science, Information Security or Information Systems.
+  * Reason being, our **Target User Profile** is restricted to NUS SoC.
+
 </div>
 
 ## Viewing help

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -3,7 +3,7 @@ layout: page
 title: User Guide
 ---
 
-TAlent Assistant™ is a **desktop, lightweight and centralized management system** catered to professors for managing
+TAlent Assistant™ is a **desktop, lightweight and centralized management system** catered to NUS School of Computing professors for managing
 the interview scheduling process of candidates applying to be undergraduate Teaching Assistants (TA). 
 Professors will be able to access the candidates’ application data easily and review their general availability for 
 scheduling interviews during office hours.


### PR DESCRIPTION
This PR consists of the following changes:
- Added additional section to address the scope of `course` entity
- Updated introduction/target user profile with further constraints to `NUS School of Computing professors`

Closes #324.