### PR TITLE
Issue #344: Fix functionality bug on edit command after find

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -322,6 +322,8 @@ public class MainWindow extends UiPart<Stage> {
     private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
         try {
             int editFlag = -1;
+            boolean isExecuted = false;
+            CommandResult commandResult = new CommandResult("");
 
             if (commandText.contains(DeleteScheduleCommand.COMMAND_WORD)
                     || commandText.contains(RemarkCommand.COMMAND_WORD)
@@ -331,12 +333,14 @@ public class MainWindow extends UiPart<Stage> {
                 handleDelete(commandText);
             } else if (commandText.contains(EditCommand.COMMAND_WORD)) {
                 try {
-                    CommandResult commandResult = logic.execute(commandText);
+                    commandResult = logic.execute(commandText);
                     logger.info("Result: " + commandResult.getFeedbackToUser());
                     resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
                     clearFocusCard();
                 } catch (CommandException e) {
                     throw e;
+                } finally {
+                    isExecuted = true;
                 }
             } else if (commandText.contains(AddScheduleCommand.COMMAND_WORD)) {
                 editFlag = handleEdit(commandText, ADD_SCHEDULE_COMMAND_INDEX);
@@ -346,23 +350,24 @@ public class MainWindow extends UiPart<Stage> {
                 clearFocusCard();
             }
 
-            CommandResult commandResult = logic.execute(commandText);
+            if (!isExecuted) {
+                commandResult = logic.execute(commandText);
 
+                if (commandResult.isShowHelp()) {
+                    handleHelp();
+                }
 
-            if (commandResult.isShowHelp()) {
-                handleHelp();
-            }
+                if (commandResult.isExit()) {
+                    handleExit();
+                }
 
-            if (commandResult.isExit()) {
-                handleExit();
-            }
+                if (commandResult.isShowFocus()) {
+                    handleFocus(commandResult);
+                }
 
-            if (commandResult.isShowFocus()) {
-                handleFocus(commandResult);
-            }
-
-            if (editFlag != -1) {
-                executeCommand(FocusCommand.COMMAND_WORD + " " + editFlag);
+                if (editFlag != -1) {
+                    executeCommand(FocusCommand.COMMAND_WORD + " " + editFlag);
+                }
             }
 
             logger.info("Result: " + commandResult.getFeedbackToUser());


### PR DESCRIPTION
Currently, there is an error in the code where the edit command executes twice.

This results in the wrong candidate records changing if edit command comes immediately after the find command.

This PR introduces a boolean check in MainWindow, to prevent repeat execution.

Note: @tiewweijian not sure if this is the best way to implement the check, but did not want to change to much of the code you implemented! Feel free to adjust or edit it on your end!

Closes #344 