### PR TITLE
Schedule Feedback Bug

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -300,9 +300,18 @@ public class MainWindow extends UiPart<Stage> {
      * Refreshes the FocusCard if all schedules are cleared so that the displayed Candidate has the latest information.
      */
     public CommandResult refreshWhenClearAllSchedule(String commandText) throws CommandException, ParseException {
+
+        int displayedIndex = -1;
+
+        if (focusListPanel != null
+                && !focusListPanelPlaceholder.getChildren().isEmpty()
+                && !logic.getFilteredInterviewSchedule().isEmpty()) {
+            displayedIndex = logic.getFilteredCandidateList().indexOf(focusListPanel.getCandidate());
+        }
+
         CommandResult commandResult = logic.execute(commandText);
-        if (focusListPanel != null && !focusListPanelPlaceholder.getChildren().isEmpty()) {
-            int displayedIndex = logic.getFilteredCandidateList().indexOf(focusListPanel.getCandidate());
+
+        if (displayedIndex != -1) {
             logger.info(String.valueOf(logic.getFilteredCandidateList().contains(focusListPanel.getCandidate())));
             executeCommand(FocusCommand.COMMAND_WORD + " " + String.valueOf(displayedIndex + 1));
         }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -303,9 +303,7 @@ public class MainWindow extends UiPart<Stage> {
 
         int displayedIndex = -1;
 
-        if (focusListPanel != null
-                && !focusListPanelPlaceholder.getChildren().isEmpty()
-                && !logic.getFilteredInterviewSchedule().isEmpty()) {
+        if (focusListPanel != null && !focusListPanelPlaceholder.getChildren().isEmpty()) {
             displayedIndex = logic.getFilteredCandidateList().indexOf(focusListPanel.getCandidate());
         }
 


### PR DESCRIPTION
Bugs reported:

#343 
1. `focus 2`
2. `schedule add candidate/2 at/04-04-2022 11:00`
3. `schedule clear`

Error message was displayed incorrectly. This was due to the fact that the schedule was cleared first, no longer able to get the `Candidate` from the `InterviewList`


#315 
`schedule clear` when the user types `view today` with an empty list.
This is also related to #343, as the updated `InterviewList` is empty, unable to retrieve `Candidate` from the updated `InterviewList`. 

In this PR, I have ensured to get the index of the `Candidate` before deleting them. It works on my end now!

Closes #343 
Closes #315 