### PR TITLE
Issue #344: Bug from `edit` after using `find` command

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -335,6 +335,7 @@ public class MainWindow extends UiPart<Stage> {
                     logger.info("Result: " + commandResult.getFeedbackToUser());
                     resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
                     clearFocusCard();
+                    return commandResult;
                 } catch (CommandException e) {
                     throw e;
                 }


### PR DESCRIPTION
@charmainehly this one is my implementation !! I added a `return commandResult` from the `edit command` to short circuit the `executeCommand` so that it won't run twice!! 